### PR TITLE
Add remaining bridge endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,23 @@ async def main() -> None:
         # Get all "households" associated with the account:
         systems = await client.system.async_all()
 
-        # Get all base stations associated with the account:
+        # Get all bridges associated with the account:
         bridges = await client.bridge.async_all()
+
+        # Get a bridge by ID:
+        bridge = await client.bridge.async_get(12345)
+
+        # Create a bridge (with associated parameters):
+        await client.bridge.async_create({"system_id": 13579, "name": "Test"})
+
+        # Update a bridge with new parameters:
+        await client.bridge.async_update(12345, {"name": "Test"})
+
+        # Reset a bridge (deprovision its WiFi credentials):
+        await client.bridge.async_reset(12345)
+
+        # Delete a bridge by ID:
+        await client.bridge.async_delete(12345)
 
         # Get all sensors associated with the account:
         sensors = await client.sensor.async_all()

--- a/aionotion/bridge.py
+++ b/aionotion/bridge.py
@@ -13,3 +13,34 @@ class Bridge:  # pylint: disable=too-few-public-methods
         """Get all bridges."""
         resp = await self._request("get", "base_stations")
         return resp["base_stations"]
+
+    async def async_create(self, attributes: dict) -> dict:
+        """Create a bridge with a specific attribute payload."""
+        resp = await self._request(
+            "post", "base_stations", json={"base_stations": attributes}
+        )
+        return resp["base_stations"]
+
+    async def async_delete(self, bridge_id: int) -> list:
+        """Delete a bridge by ID."""
+        resp = await self._request("delete", "base_stations/{0}".format(bridge_id))
+        return resp["base_stations"]
+
+    async def async_get(self, bridge_id: int) -> dict:
+        """Get a bridge by ID."""
+        resp = await self._request("get", "base_stations/{0}".format(bridge_id))
+        return resp["base_stations"]
+
+    async def async_reset(self, bridge_id: int) -> dict:
+        """Reset a bridge (clear its wifi credentials) by ID."""
+        resp = await self._request("put", "base_stations/{0}/reset".format(bridge_id))
+        return resp["base_stations"]
+
+    async def async_update(self, bridge_id: int, new_attributes: dict) -> dict:
+        """Update a bridge with a specific attribute payload."""
+        resp = await self._request(
+            "put",
+            "base_stations/{0}".format(bridge_id),
+            json={"base_stations": new_attributes},
+        )
+        return resp["base_stations"]

--- a/aionotion/client.py
+++ b/aionotion/client.py
@@ -47,13 +47,12 @@ class Client:  # pylint: disable=too-few-public-methods
         async with self._session.request(
             method, url, headers=headers, params=params, json=json
         ) as resp:
+            data = await resp.json(content_type=None)
             try:
                 resp.raise_for_status()
-                return await resp.json(content_type=None)
-            except ClientError as err:
-                raise RequestError(
-                    "Error requesting data from {0}: {1}".format(url, err)
-                )
+                return data
+            except ClientError:
+                raise RequestError(data["errors"][0]["title"])
 
     async def async_authenticate(self, email: str, password: str) -> None:
         """Authenticate the user and retrieve an authentication token."""

--- a/example.py
+++ b/example.py
@@ -18,18 +18,18 @@ async def main() -> None:
     logging.basicConfig(level=logging.INFO)
     async with ClientSession() as session:
         try:
-            api = await async_get_client(EMAIL, PASSWORD, session)
+            client = await async_get_client(EMAIL, PASSWORD, session)
 
-            systems = await api.async_get_systems()
-            _LOGGER.info("SYSTEMS: %s", systems)
+            bridges = await client.bridge.async_all()
+            _LOGGER.info("BRIDGES: %s", bridges)
 
-            base_stations = await api.async_get_base_stations()
-            _LOGGER.info("BASE STATIONS: %s", base_stations)
-
-            sensors = await api.async_get_sensors()
+            sensors = await client.sensor.async_all()
             _LOGGER.info("SENSORS: %s", sensors)
 
-            tasks = await api.async_get_tasks()
+            systems = await client.system.async_all()
+            _LOGGER.info("SYSTEMS: %s", systems)
+
+            tasks = await client.task.async_all()
             _LOGGER.info("TASKS: %s", tasks)
         except NotionError as err:
             _LOGGER.error("There was an error: %s", err)

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -6,7 +6,7 @@ from ..const import TEST_EMAIL, TEST_TOKEN
 
 @pytest.fixture()
 def auth_success_json():
-    """Define a response to /users/sign_in."""
+    """Define a response to GET /users/sign_in."""
     return {
         "users": {
             "id": 12345,
@@ -26,3 +26,9 @@ def auth_success_json():
             "authentication_token": TEST_TOKEN,
         },
     }
+
+
+@pytest.fixture()
+def bad_api_json():
+    """Define a response to GET /bad_endpoint."""
+    return {"errors": [{"title": "No records found"}]}

--- a/tests/fixtures/bridge.py
+++ b/tests/fixtures/bridge.py
@@ -27,3 +27,129 @@ def bridge_all_json():
             }
         ]
     }
+
+
+@pytest.fixture()
+def bridge_create_json():
+    """Define a response to POST /base_stations."""
+    return {
+        "base_stations": [
+            {
+                "id": 12345,
+                "name": None,
+                "mode": "home",
+                "hardware_id": "0x1234567890abcdef",
+                "hardware_revision": 4,
+                "firmware_version": {
+                    "wifi": "0.121.0",
+                    "wifi_app": "3.3.0",
+                    "silabs": "1.0.1",
+                },
+                "missing_at": None,
+                "created_at": "2019-04-30T01:43:50.497Z",
+                "updated_at": "2019-04-30T01:44:43.749Z",
+                "system_id": 12345,
+                "firmware": {"wifi": "0.121.0", "wifi_app": "3.3.0", "silabs": "1.0.1"},
+                "links": {"system": 12345},
+            },
+            {
+                "id": 98765,
+                "name": "New Bridge",
+                "mode": "home",
+                "hardware_id": "0x1234567890abcdef",
+                "hardware_revision": 4,
+                "firmware_version": {
+                    "wifi": "0.121.0",
+                    "wifi_app": "3.3.0",
+                    "silabs": "1.0.1",
+                },
+                "missing_at": None,
+                "created_at": "2019-04-30T01:43:50.497Z",
+                "updated_at": "2019-04-30T01:44:43.749Z",
+                "system_id": 12345,
+                "firmware": {"wifi": "0.121.0", "wifi_app": "3.3.0", "silabs": "1.0.1"},
+                "links": {"system": 12345},
+            },
+        ]
+    }
+
+
+@pytest.fixture()
+def bridge_delete_json():
+    """Define a response to DELETE /base_stations/:id."""
+    return {"base_stations": []}
+
+
+@pytest.fixture()
+def bridge_get_json():
+    """Define a response to GET /base_stations/:id."""
+    return {
+        "base_stations": {
+            "id": 12345,
+            "name": "My Bridge",
+            "mode": "home",
+            "hardware_id": "0x1234567890abcdef",
+            "hardware_revision": 4,
+            "firmware_version": {
+                "wifi": "0.121.0",
+                "wifi_app": "3.3.0",
+                "silabs": "1.0.1",
+            },
+            "missing_at": None,
+            "created_at": "2019-04-30T01:43:50.497Z",
+            "updated_at": "2019-04-30T01:44:43.749Z",
+            "system_id": 12345,
+            "firmware": {"wifi": "0.121.0", "wifi_app": "3.3.0", "silabs": "1.0.1"},
+            "links": {"system": 12345},
+        }
+    }
+
+
+@pytest.fixture()
+def bridge_reset_json():
+    """Define a response to PUT /base_stations/:id/reset."""
+    return {
+        "base_stations": {
+            "id": 12345,
+            "name": "My Bridge",
+            "mode": "home",
+            "hardware_id": "0x1234567890abcdef",
+            "hardware_revision": 4,
+            "firmware_version": {
+                "wifi": "0.121.0",
+                "wifi_app": "3.3.0",
+                "silabs": "1.0.1",
+            },
+            "missing_at": None,
+            "created_at": "2019-04-30T01:43:50.497Z",
+            "updated_at": "2019-04-30T01:44:43.749Z",
+            "system_id": 12345,
+            "firmware": {"wifi": "0.121.0", "wifi_app": "3.3.0", "silabs": "1.0.1"},
+            "links": {"system": 12345},
+        }
+    }
+
+
+@pytest.fixture()
+def bridge_update_json():
+    """Define a response to PUT /base_stations/:id."""
+    return {
+        "base_stations": {
+            "id": 12345,
+            "name": "My Updated Name",
+            "mode": "home",
+            "hardware_id": "0x1234567890abcdef",
+            "hardware_revision": 4,
+            "firmware_version": {
+                "wifi": "0.121.0",
+                "wifi_app": "3.3.0",
+                "silabs": "1.0.1",
+            },
+            "missing_at": None,
+            "created_at": "2019-04-30T01:43:50.497Z",
+            "updated_at": "2019-04-30T01:44:43.749Z",
+            "system_id": 12345,
+            "firmware": {"wifi": "0.121.0", "wifi_app": "3.3.0", "silabs": "1.0.1"},
+            "links": {"system": 12345},
+        }
+    }

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -9,7 +9,14 @@ from aionotion import async_get_client
 
 from .const import TEST_EMAIL, TEST_PASSWORD
 from .fixtures import auth_success_json  # noqa: F401
-from .fixtures.bridge import bridge_all_json  # noqa: F401
+from .fixtures.bridge import (  # noqa: F401
+    bridge_all_json,
+    bridge_create_json,
+    bridge_delete_json,
+    bridge_get_json,
+    bridge_reset_json,
+    bridge_update_json,
+)
 
 
 @pytest.mark.asyncio
@@ -35,3 +42,137 @@ async def test_bridge_all(
         bridges = await client.bridge.async_all()
 
         assert len(bridges) == 1
+
+
+@pytest.mark.asyncio
+async def test_bridge_create(
+    aresponses, event_loop, auth_success_json, bridge_create_json  # noqa: F811
+):
+    """Test creating a bridge."""
+    aresponses.add(
+        "api.getnotion.com",
+        "/api/users/sign_in",
+        "post",
+        aresponses.Response(text=json.dumps(auth_success_json), status=200),
+    )
+    aresponses.add(
+        "api.getnotion.com",
+        "/api/base_stations",
+        "post",
+        aresponses.Response(text=json.dumps(bridge_create_json), status=200),
+    )
+
+    async with aiohttp.ClientSession(loop=event_loop) as websession:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+        create_resp = await client.bridge.async_create(
+            {"name": "New Bridge", "system_id": 98765}
+        )
+
+        assert len(create_resp) == 2
+        assert create_resp[1]["id"] == 98765
+        assert create_resp[1]["name"] == "New Bridge"
+
+
+@pytest.mark.asyncio
+async def test_bridge_delete(
+    aresponses, event_loop, auth_success_json, bridge_delete_json  # noqa: F811
+):
+    """Test deleting a bridge."""
+    aresponses.add(
+        "api.getnotion.com",
+        "/api/users/sign_in",
+        "post",
+        aresponses.Response(text=json.dumps(auth_success_json), status=200),
+    )
+    aresponses.add(
+        "api.getnotion.com",
+        "/api/base_stations/12345",
+        "delete",
+        aresponses.Response(text=json.dumps(bridge_delete_json), status=200),
+    )
+
+    async with aiohttp.ClientSession(loop=event_loop) as websession:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+        delete_resp = await client.bridge.async_delete(12345)
+
+        assert not delete_resp
+
+
+@pytest.mark.asyncio
+async def test_bridge_get(
+    aresponses, event_loop, auth_success_json, bridge_get_json  # noqa: F811
+):
+    """Test getting a bridge by ID."""
+    aresponses.add(
+        "api.getnotion.com",
+        "/api/users/sign_in",
+        "post",
+        aresponses.Response(text=json.dumps(auth_success_json), status=200),
+    )
+    aresponses.add(
+        "api.getnotion.com",
+        "/api/base_stations/12345",
+        "get",
+        aresponses.Response(text=json.dumps(bridge_get_json), status=200),
+    )
+
+    async with aiohttp.ClientSession(loop=event_loop) as websession:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+        bridge = await client.bridge.async_get(12345)
+
+        assert bridge["id"] == 12345
+        assert bridge["name"] == "My Bridge"
+
+
+@pytest.mark.asyncio
+async def test_bridge_reset(
+    aresponses, event_loop, auth_success_json, bridge_reset_json  # noqa: F811
+):
+    """Test deleting a bridge."""
+    aresponses.add(
+        "api.getnotion.com",
+        "/api/users/sign_in",
+        "post",
+        aresponses.Response(text=json.dumps(auth_success_json), status=200),
+    )
+    aresponses.add(
+        "api.getnotion.com",
+        "/api/base_stations/12345/reset",
+        "put",
+        aresponses.Response(text=json.dumps(bridge_reset_json), status=200),
+    )
+
+    async with aiohttp.ClientSession(loop=event_loop) as websession:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+        reset_resp = await client.bridge.async_reset(12345)
+
+        assert reset_resp["id"] == 12345
+        assert reset_resp["name"] == "My Bridge"
+
+
+@pytest.mark.asyncio
+async def test_bridge_update(
+    aresponses, event_loop, auth_success_json, bridge_update_json  # noqa: F811
+):
+    """Test deleting a bridge."""
+    aresponses.add(
+        "api.getnotion.com",
+        "/api/users/sign_in",
+        "post",
+        aresponses.Response(text=json.dumps(auth_success_json), status=200),
+    )
+    aresponses.add(
+        "api.getnotion.com",
+        "/api/base_stations/12345",
+        "put",
+        aresponses.Response(text=json.dumps(bridge_update_json), status=200),
+    )
+
+    async with aiohttp.ClientSession(loop=event_loop) as websession:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+        reset_resp = await client.bridge.async_update(
+            12345, {"name": "My Updated Name"}
+        )
+
+        assert reset_resp["id"] == 12345
+        assert reset_resp["name"] == "My Updated Name"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,5 @@
 """Define tests for the client."""
-# pylint: disable=redefined-outer-name, unused-import
+# pylint: disable=protected-access,redefined-outer-name,unused-import
 import json
 
 import aiohttp
@@ -9,26 +9,35 @@ from aionotion import async_get_client
 from aionotion.errors import RequestError
 
 from .const import TEST_EMAIL, TEST_PASSWORD, TEST_TOKEN
-from .fixtures import auth_success_json  # noqa: F401
+from .fixtures import auth_success_json, bad_api_json  # noqa: F401
 
 
 @pytest.mark.asyncio
-async def test_api_error(aresponses, event_loop):
+async def test_api_error(
+    aresponses, auth_success_json, bad_api_json, event_loop  # noqa: F811
+):
     """Test an invalid API call."""
     aresponses.add(
         "api.getnotion.com",
         "/api/users/sign_in",
         "post",
-        aresponses.Response(text="", status=500),
+        aresponses.Response(text=json.dumps(auth_success_json), status=200),
+    )
+    aresponses.add(
+        "api.getnotion.com",
+        "/api/bad_endpoint",
+        "get",
+        aresponses.Response(text=json.dumps(bad_api_json), status=404),
     )
 
     async with aiohttp.ClientSession(loop=event_loop) as websession:
         with pytest.raises(RequestError):
-            await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+            client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+            await client._request("get", "bad_endpoint")
 
 
 @pytest.mark.asyncio
-async def test_auth_success(aresponses, event_loop, auth_success_json):  # noqa: F811
+async def test_auth_success(aresponses, auth_success_json, event_loop):  # noqa: F811
     """Test authenticating against the API and getting a token."""
     aresponses.add(
         "api.getnotion.com",


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds functions for the remaining bridge API endpoints:

* `async def async_all(self) -> list`
* `async def async_create(self, attributes: dict) -> dict`
* `async def async_delete(self, bridge_id: int) -> list`
* `async def async_get(self, bridge_id: int) -> dict`
* `async def async_reset(self, bridge_id: int) -> dict`
* `async def async_update(self, bridge_id: int, new_attributes: dict) -> dict`

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
