### PR TITLE
Update bridge endpoints based on better API understanding

### DIFF
--- a/aionotion/bridge.py
+++ b/aionotion/bridge.py
@@ -23,8 +23,7 @@ class Bridge:  # pylint: disable=too-few-public-methods
 
     async def async_delete(self, bridge_id: int) -> list:
         """Delete a bridge by ID."""
-        resp = await self._request("delete", "base_stations/{0}".format(bridge_id))
-        return resp["base_stations"]
+        await self._request("delete", "base_stations/{0}".format(bridge_id))
 
     async def async_get(self, bridge_id: int) -> dict:
         """Get a bridge by ID."""

--- a/aionotion/bridge.py
+++ b/aionotion/bridge.py
@@ -21,7 +21,7 @@ class Bridge:  # pylint: disable=too-few-public-methods
         )
         return resp["base_stations"]
 
-    async def async_delete(self, bridge_id: int) -> list:
+    async def async_delete(self, bridge_id: int) -> None:
         """Delete a bridge by ID."""
         await self._request("delete", "base_stations/{0}".format(bridge_id))
 

--- a/tests/fixtures/bridge.py
+++ b/tests/fixtures/bridge.py
@@ -33,51 +33,25 @@ def bridge_all_json():
 def bridge_create_json():
     """Define a response to POST /base_stations."""
     return {
-        "base_stations": [
-            {
-                "id": 12345,
-                "name": None,
-                "mode": "home",
-                "hardware_id": "0x1234567890abcdef",
-                "hardware_revision": 4,
-                "firmware_version": {
-                    "wifi": "0.121.0",
-                    "wifi_app": "3.3.0",
-                    "silabs": "1.0.1",
-                },
-                "missing_at": None,
-                "created_at": "2019-04-30T01:43:50.497Z",
-                "updated_at": "2019-04-30T01:44:43.749Z",
-                "system_id": 12345,
-                "firmware": {"wifi": "0.121.0", "wifi_app": "3.3.0", "silabs": "1.0.1"},
-                "links": {"system": 12345},
+        "base_stations": {
+            "id": 98765,
+            "name": "New Bridge",
+            "mode": "home",
+            "hardware_id": "0x1234567890abcdef",
+            "hardware_revision": 4,
+            "firmware_version": {
+                "wifi": "0.121.0",
+                "wifi_app": "3.3.0",
+                "silabs": "1.0.1",
             },
-            {
-                "id": 98765,
-                "name": "New Bridge",
-                "mode": "home",
-                "hardware_id": "0x1234567890abcdef",
-                "hardware_revision": 4,
-                "firmware_version": {
-                    "wifi": "0.121.0",
-                    "wifi_app": "3.3.0",
-                    "silabs": "1.0.1",
-                },
-                "missing_at": None,
-                "created_at": "2019-04-30T01:43:50.497Z",
-                "updated_at": "2019-04-30T01:44:43.749Z",
-                "system_id": 12345,
-                "firmware": {"wifi": "0.121.0", "wifi_app": "3.3.0", "silabs": "1.0.1"},
-                "links": {"system": 12345},
-            },
-        ]
+            "missing_at": None,
+            "created_at": "2019-04-30T01:43:50.497Z",
+            "updated_at": "2019-04-30T01:44:43.749Z",
+            "system_id": 12345,
+            "firmware": {"wifi": "0.121.0", "wifi_app": "3.3.0", "silabs": "1.0.1"},
+            "links": {"system": 12345},
+        }
     }
-
-
-@pytest.fixture()
-def bridge_delete_json():
-    """Define a response to DELETE /base_stations/:id."""
-    return {"base_stations": []}
 
 
 @pytest.fixture()

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -12,7 +12,6 @@ from .fixtures import auth_success_json  # noqa: F401
 from .fixtures.bridge import (  # noqa: F401
     bridge_all_json,
     bridge_create_json,
-    bridge_delete_json,
     bridge_get_json,
     bridge_reset_json,
     bridge_update_json,
@@ -68,15 +67,12 @@ async def test_bridge_create(
             {"name": "New Bridge", "system_id": 98765}
         )
 
-        assert len(create_resp) == 2
-        assert create_resp[1]["id"] == 98765
-        assert create_resp[1]["name"] == "New Bridge"
+        assert create_resp["id"] == 98765
+        assert create_resp["name"] == "New Bridge"
 
 
 @pytest.mark.asyncio
-async def test_bridge_delete(
-    aresponses, event_loop, auth_success_json, bridge_delete_json  # noqa: F811
-):
+async def test_bridge_delete(aresponses, event_loop, auth_success_json):  # noqa: F811
     """Test deleting a bridge."""
     aresponses.add(
         "api.getnotion.com",
@@ -88,14 +84,12 @@ async def test_bridge_delete(
         "api.getnotion.com",
         "/api/base_stations/12345",
         "delete",
-        aresponses.Response(text=json.dumps(bridge_delete_json), status=200),
+        aresponses.Response(text=None, status=200),
     )
 
     async with aiohttp.ClientSession(loop=event_loop) as websession:
         client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
-        delete_resp = await client.bridge.async_delete(12345)
-
-        assert not delete_resp
+        await client.bridge.async_delete(12345)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

After a more careful reading of the API docs, there are some things that I misunderstood:

* Creating a bridge returns only the payload of the created bridge.
* Deleting a bridge only returns a response code; there is no body.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
