### PR TITLE
Switch to f-strings (and remove support for Python 3.5.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,8 @@
 
 `aionotion` is currently supported on:
 
-* Python 3.5
 * Python 3.6
 * Python 3.7
-
-However, running the test suite currently requires Python 3.6 or higher; tests
-run on Python 3.5 will fail.
 
 # Installation
 

--- a/aionotion/bridge.py
+++ b/aionotion/bridge.py
@@ -23,23 +23,21 @@ class Bridge:  # pylint: disable=too-few-public-methods
 
     async def async_delete(self, bridge_id: int) -> None:
         """Delete a bridge by ID."""
-        await self._request("delete", "base_stations/{0}".format(bridge_id))
+        await self._request("delete", f"base_stations/{bridge_id}")
 
     async def async_get(self, bridge_id: int) -> dict:
         """Get a bridge by ID."""
-        resp = await self._request("get", "base_stations/{0}".format(bridge_id))
+        resp = await self._request("get", f"base_stations/{bridge_id}")
         return resp["base_stations"]
 
     async def async_reset(self, bridge_id: int) -> dict:
         """Reset a bridge (clear its wifi credentials) by ID."""
-        resp = await self._request("put", "base_stations/{0}/reset".format(bridge_id))
+        resp = await self._request("put", f"base_stations/{bridge_id}/reset")
         return resp["base_stations"]
 
     async def async_update(self, bridge_id: int, new_attributes: dict) -> dict:
         """Update a bridge with a specific attribute payload."""
         resp = await self._request(
-            "put",
-            "base_stations/{0}".format(bridge_id),
-            json={"base_stations": new_attributes},
+            "put", f"base_stations/{bridge_id}", json={"base_stations": new_attributes}
         )
         return resp["base_stations"]

--- a/aionotion/client.py
+++ b/aionotion/client.py
@@ -35,16 +35,16 @@ class Client:  # pylint: disable=too-few-public-methods
         *,
         headers: dict = None,
         params: dict = None,
-        json: dict = None
+        json: dict = None,
     ) -> dict:
         """Make a request the API.com."""
-        url = "{0}/{1}".format(API_BASE, endpoint)
+        url = f"{API_BASE}/{endpoint}"
 
         if not headers:
             headers = {}
 
         if self._token:
-            headers["Authorization"] = "Token token={0}".format(self._token)
+            headers["Authorization"] = f"Token token={self._token}"
 
         async with self._session.request(
             method, url, headers=headers, params=params, json=json

--- a/aionotion/device.py
+++ b/aionotion/device.py
@@ -21,9 +21,9 @@ class Device:  # pylint: disable=too-few-public-methods
 
     async def async_delete(self, device_id: int) -> None:
         """Delete a device by ID."""
-        await self._request("delete", "devices/{0}".format(device_id))
+        await self._request("delete", f"devices/{device_id}")
 
     async def async_get(self, device_id: int) -> dict:
         """Get a device by ID."""
-        resp = await self._request("get", "devices/{0}".format(device_id))
+        resp = await self._request("get", f"devices/{device_id}")
         return resp["devices"]

--- a/aionotion/sensor.py
+++ b/aionotion/sensor.py
@@ -21,16 +21,16 @@ class Sensor:  # pylint: disable=too-few-public-methods
 
     async def async_delete(self, sensor_id: int) -> None:
         """Delete a sensor by ID."""
-        await self._request("delete", "sensors/{0}".format(sensor_id))
+        await self._request("delete", f"sensors/{sensor_id}")
 
     async def async_get(self, sensor_id: int) -> dict:
         """Get a sensor by ID."""
-        resp = await self._request("get", "sensors/{0}".format(sensor_id))
+        resp = await self._request("get", f"sensors/{sensor_id}")
         return resp["sensors"]
 
     async def async_update(self, sensor_id: int, new_attributes: dict) -> dict:
         """Update a sensor with a specific attribute payload."""
         resp = await self._request(
-            "put", "sensors/{0}".format(sensor_id), json={"sensors": new_attributes}
+            "put", f"sensors/{sensor_id}", json={"sensors": new_attributes}
         )
         return resp["sensors"]

--- a/aionotion/system.py
+++ b/aionotion/system.py
@@ -21,16 +21,16 @@ class System:  # pylint: disable=too-few-public-methods
 
     async def async_delete(self, system_id: int) -> None:
         """Delete a system by ID."""
-        await self._request("delete", "systems/{0}".format(system_id))
+        await self._request("delete", f"systems/{system_id}")
 
     async def async_get(self, system_id: int) -> dict:
         """Get a system by ID."""
-        resp = await self._request("get", "systems/{0}".format(system_id))
+        resp = await self._request("get", f"systems/{system_id}")
         return resp["systems"]
 
     async def async_update(self, system_id: int, new_attributes: dict) -> dict:
         """Update a system with a specific attribute payload."""
         resp = await self._request(
-            "put", "systems/{0}".format(system_id), json={"systems": new_attributes}
+            "put", f"systems/{system_id}", json={"systems": new_attributes}
         )
         return resp["systems"]

--- a/aionotion/task.py
+++ b/aionotion/task.py
@@ -19,20 +19,18 @@ class Task:  # pylint: disable=too-few-public-methods
         """Create new tasks based upon a list of attribute dicts."""
         resp = await self._request(
             "post",
-            "sensors/{0}/tasks".format(sensor_id),
+            f"sensors/{sensor_id}/tasks",
             json={"sensor_id": sensor_id, "tasks": tasks},
         )
         return resp["tasks"]
 
     async def async_delete(self, sensor_id: int, task_id: str) -> None:
         """Delete a task by ID."""
-        await self._request(
-            "delete", "sensors/{0}/tasks/{1}".format(sensor_id, task_id)
-        )
+        await self._request("delete", f"sensors/{sensor_id}/tasks/{task_id}")
 
     async def async_get(self, task_id: str) -> dict:
         """Get a task by ID."""
-        resp = await self._request("get", "tasks/{0}".format(task_id))
+        resp = await self._request("get", f"tasks/{task_id}")
         return resp["tasks"]
 
     async def async_history(
@@ -41,7 +39,7 @@ class Task:  # pylint: disable=too-few-public-methods
         """Get the history of a task's values between two datetimes."""
         resp = await self._request(
             "get",
-            "tasks/{0}/data".format(task_id),
+            f"tasks/{task_id}/data",
             params={
                 "data_before": data_before.isoformat(),
                 "data_after": data_after.isoformat(),

--- a/setup.py
+++ b/setup.py
@@ -14,17 +14,17 @@ from shutil import rmtree
 from setuptools import find_packages, setup, Command
 
 # Package meta-data.
-NAME = 'aionotion'
-DESCRIPTION = 'A simple Python 3 library for Notion Home Monitoring'
-URL = 'https://github.com/bachya/aionotion'
-EMAIL = 'bachya1208@gmail.com'
-AUTHOR = 'Aaron Bach'
-REQUIRES_PYTHON = '>=3.5.3'
+NAME = "aionotion"
+DESCRIPTION = "A simple Python 3 library for Notion Home Monitoring"
+URL = "https://github.com/bachya/aionotion"
+EMAIL = "bachya1208@gmail.com"
+AUTHOR = "Aaron Bach"
+REQUIRES_PYTHON = ">=3.6.0"
 VERSION = None
 
 # What packages are required for this module to be executed?
 REQUIRED = [  # type: ignore
-    'aiohttp',
+    "aiohttp"
 ]
 
 # The rest you shouldn't have to touch too much :)
@@ -37,29 +37,28 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 # Import the README and use it as the long-description.
 # Note: this will only work if 'README.md' is present in your MANIFEST.in file!
-with io.open(os.path.join(HERE, 'README.md'), encoding='utf-8') as f:
-    LONG_DESC = '\n' + f.read()
+with io.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
+    LONG_DESC = "\n" + f.read()
 
 # Load the package's __version__.py module as a dictionary.
 ABOUT = {}  # type: ignore
 if not VERSION:
-    with open(os.path.join(HERE, NAME, 'const.py')) as f:
+    with open(os.path.join(HERE, NAME, "const.py")) as f:
         exec(f.read(), ABOUT)  # pylint: disable=exec-used
 else:
-    ABOUT['__version__'] = VERSION
-
+    ABOUT["__version__"] = VERSION
 
 
 class UploadCommand(Command):
     """Support setup.py upload."""
 
-    description = 'Build and publish the package.'
+    description = "Build and publish the package."
     user_options = []  # type: ignore
 
     @staticmethod
     def status(string):
-        """Prints things in bold."""
-        print('\033[1m{0}\033[0m'.format(string))
+        """Print things in bold."""
+        print(f"\033[1m{string}\033[0m")
 
     def initialize_options(self):
         """Add options for initialization."""
@@ -72,21 +71,20 @@ class UploadCommand(Command):
     def run(self):
         """Run."""
         try:
-            self.status('Removing previous builds…')
-            rmtree(os.path.join(HERE, 'dist'))
+            self.status("Removing previous builds…")
+            rmtree(os.path.join(HERE, "dist"))
         except OSError:
             pass
 
-        self.status('Building Source and Wheel (universal) distribution…')
-        os.system('{0} setup.py sdist bdist_wheel --universal'.format(
-            sys.executable))
+        self.status("Building Source and Wheel (universal) distribution…")
+        os.system(f"{sys.executable} setup.py sdist bdist_wheel --universal")
 
-        self.status('Uploading the package to PyPi via Twine…')
-        os.system('twine upload dist/*')
+        self.status("Uploading the package to PyPi via Twine…")
+        os.system("twine upload dist/*")
 
-        self.status('Pushing git tags…')
-        os.system('git tag v{0}'.format(ABOUT['__version__']))
-        os.system('git push --tags')
+        self.status("Pushing git tags…")
+        os.system(f"git tag v{ABOUT['__version__']}")
+        os.system("git push --tags")
 
         sys.exit()
 
@@ -94,38 +92,34 @@ class UploadCommand(Command):
 # Where the magic happens:
 setup(
     name=NAME,
-    version=ABOUT['__version__'],
+    version=ABOUT["__version__"],
     description=DESCRIPTION,
     long_description=LONG_DESC,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     author=AUTHOR,
     author_email=EMAIL,
     python_requires=REQUIRES_PYTHON,
     url=URL,
-    packages=find_packages(exclude=('tests',)),
+    packages=find_packages(exclude=("tests",)),
     # If your package is a single module, use this instead of 'packages':
     # py_modules=['mypackage'],
-
     # entry_points={
     #     'console_scripts': ['mycli=mymodule:cli'],
     # },
     install_requires=REQUIRED,
     include_package_data=True,
-    license='MIT',
+    license="MIT",
     classifiers=[
         # Trove classifiers
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy'
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
     ],
     # $ setup.py publish support.
-    cmdclass={
-        'upload': UploadCommand,
-    },
+    cmdclass={"upload": UploadCommand},
 )


### PR DESCRIPTION
**Describe what the PR does:**

This PR drops runtime support for Python 3.5.3 and makes the minimum runtime version 3.6. One of a few benefits to follow: we now get to use f-strings.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)

