### PR TITLE
Add Python 3.6-style variable type annotations

### DIFF
--- a/aionotion/bridge.py
+++ b/aionotion/bridge.py
@@ -7,16 +7,16 @@ class Bridge:  # pylint: disable=too-few-public-methods
 
     def __init__(self, request: Callable) -> None:
         """Initialize."""
-        self._request = request
+        self._request: Callable = request
 
     async def async_all(self) -> list:
         """Get all bridges."""
-        resp = await self._request("get", "base_stations")
+        resp: dict = await self._request("get", "base_stations")
         return resp["base_stations"]
 
     async def async_create(self, attributes: dict) -> dict:
         """Create a bridge with a specific attribute payload."""
-        resp = await self._request(
+        resp: dict = await self._request(
             "post", "base_stations", json={"base_stations": attributes}
         )
         return resp["base_stations"]
@@ -27,17 +27,17 @@ class Bridge:  # pylint: disable=too-few-public-methods
 
     async def async_get(self, bridge_id: int) -> dict:
         """Get a bridge by ID."""
-        resp = await self._request("get", f"base_stations/{bridge_id}")
+        resp: dict = await self._request("get", f"base_stations/{bridge_id}")
         return resp["base_stations"]
 
     async def async_reset(self, bridge_id: int) -> dict:
         """Reset a bridge (clear its wifi credentials) by ID."""
-        resp = await self._request("put", f"base_stations/{bridge_id}/reset")
+        resp: dict = await self._request("put", f"base_stations/{bridge_id}/reset")
         return resp["base_stations"]
 
     async def async_update(self, bridge_id: int, new_attributes: dict) -> dict:
         """Update a bridge with a specific attribute payload."""
-        resp = await self._request(
+        resp: dict = await self._request(
             "put", f"base_stations/{bridge_id}", json={"base_stations": new_attributes}
         )
         return resp["base_stations"]

--- a/aionotion/client.py
+++ b/aionotion/client.py
@@ -11,7 +11,7 @@ from .sensor import Sensor
 from .system import System
 from .task import Task
 
-API_BASE = "https://api.getnotion.com/api"
+API_BASE: str = "https://api.getnotion.com/api"
 
 
 class Client:  # pylint: disable=too-few-public-methods
@@ -19,14 +19,14 @@ class Client:  # pylint: disable=too-few-public-methods
 
     def __init__(self, session: ClientSession) -> None:
         """Initialize."""
-        self._session = session
-        self._token = None  # type: Optional[str]
+        self._session: ClientSession = session
+        self._token: Optional[str] = None
 
-        self.bridge = Bridge(self._request)
-        self.device = Device(self._request)
-        self.sensor = Sensor(self._request)
-        self.system = System(self._request)
-        self.task = Task(self._request)
+        self.bridge: Bridge = Bridge(self._request)
+        self.device: Device = Device(self._request)
+        self.sensor: Sensor = Sensor(self._request)
+        self.system: System = System(self._request)
+        self.task: Task = Task(self._request)
 
     async def _request(
         self,
@@ -38,7 +38,7 @@ class Client:  # pylint: disable=too-few-public-methods
         json: dict = None,
     ) -> dict:
         """Make a request the API.com."""
-        url = f"{API_BASE}/{endpoint}"
+        url: str = f"{API_BASE}/{endpoint}"
 
         if not headers:
             headers = {}
@@ -49,7 +49,7 @@ class Client:  # pylint: disable=too-few-public-methods
         async with self._session.request(
             method, url, headers=headers, params=params, json=json
         ) as resp:
-            data = await resp.json(content_type=None)
+            data: dict = await resp.json(content_type=None)
             try:
                 resp.raise_for_status()
                 return data
@@ -60,7 +60,7 @@ class Client:  # pylint: disable=too-few-public-methods
 
     async def async_authenticate(self, email: str, password: str) -> None:
         """Authenticate the user and retrieve an authentication token."""
-        auth_response = await self._request(
+        auth_response: dict = await self._request(
             "post",
             "users/sign_in",
             json={"sessions": {"email": email, "password": password}},
@@ -71,6 +71,6 @@ class Client:  # pylint: disable=too-few-public-methods
 
 async def async_get_client(email: str, password: str, session: ClientSession) -> Client:
     """Return an authenticated API object."""
-    client = Client(session)
+    client: Client = Client(session)
     await client.async_authenticate(email, password)
     return client

--- a/aionotion/const.py
+++ b/aionotion/const.py
@@ -1,2 +1,2 @@
 """Define package constants."""
-__version__ = "1.1.0"
+__version__: str = "1.1.0"

--- a/aionotion/device.py
+++ b/aionotion/device.py
@@ -2,21 +2,23 @@
 from typing import Callable
 
 
-class Device:  # pylint: disable=too-few-public-methods
+class Device:
     """Define an object to interact with all endpoints."""
 
     def __init__(self, request: Callable) -> None:
         """Initialize."""
-        self._request = request
+        self._request: Callable = request
 
     async def async_all(self) -> list:
         """Get all devices."""
-        resp = await self._request("get", "devices")
+        resp: dict = await self._request("get", "devices")
         return resp["devices"]
 
     async def async_create(self, attributes: dict) -> dict:
         """Create a device with a specific attribute payload."""
-        resp = await self._request("post", "devices", json={"devices": attributes})
+        resp: dict = await self._request(
+            "post", "devices", json={"devices": attributes}
+        )
         return resp["devices"]
 
     async def async_delete(self, device_id: int) -> None:
@@ -25,5 +27,5 @@ class Device:  # pylint: disable=too-few-public-methods
 
     async def async_get(self, device_id: int) -> dict:
         """Get a device by ID."""
-        resp = await self._request("get", f"devices/{device_id}")
+        resp: dict = await self._request("get", f"devices/{device_id}")
         return resp["devices"]

--- a/aionotion/sensor.py
+++ b/aionotion/sensor.py
@@ -2,21 +2,23 @@
 from typing import Callable
 
 
-class Sensor:  # pylint: disable=too-few-public-methods
+class Sensor:
     """Define an object to interact with all endpoints."""
 
     def __init__(self, request: Callable) -> None:
         """Initialize."""
-        self._request = request
+        self._request: Callable = request
 
     async def async_all(self) -> list:
         """Get all sensors."""
-        resp = await self._request("get", "sensors")
+        resp: dict = await self._request("get", "sensors")
         return resp["sensors"]
 
     async def async_create(self, attributes: dict) -> dict:
         """Create a sensor with a specific attribute payload."""
-        resp = await self._request("post", "sensors", json={"sensors": attributes})
+        resp: dict = await self._request(
+            "post", "sensors", json={"sensors": attributes}
+        )
         return resp["sensors"]
 
     async def async_delete(self, sensor_id: int) -> None:
@@ -25,12 +27,12 @@ class Sensor:  # pylint: disable=too-few-public-methods
 
     async def async_get(self, sensor_id: int) -> dict:
         """Get a sensor by ID."""
-        resp = await self._request("get", f"sensors/{sensor_id}")
+        resp: dict = await self._request("get", f"sensors/{sensor_id}")
         return resp["sensors"]
 
     async def async_update(self, sensor_id: int, new_attributes: dict) -> dict:
         """Update a sensor with a specific attribute payload."""
-        resp = await self._request(
+        resp: dict = await self._request(
             "put", f"sensors/{sensor_id}", json={"sensors": new_attributes}
         )
         return resp["sensors"]

--- a/aionotion/system.py
+++ b/aionotion/system.py
@@ -2,21 +2,23 @@
 from typing import Callable
 
 
-class System:  # pylint: disable=too-few-public-methods
+class System:
     """Define an object to interact with all endpoints."""
 
     def __init__(self, request: Callable) -> None:
         """Initialize."""
-        self._request = request
+        self._request: Callable = request
 
     async def async_all(self) -> list:
         """Get all systems."""
-        resp = await self._request("get", "systems")
+        resp: dict = await self._request("get", "systems")
         return resp["systems"]
 
     async def async_create(self, attributes: dict) -> dict:
         """Create a system with a specific attribute payload."""
-        resp = await self._request("post", "systems", json={"systems": attributes})
+        resp: dict = await self._request(
+            "post", "systems", json={"systems": attributes}
+        )
         return resp["systems"]
 
     async def async_delete(self, system_id: int) -> None:
@@ -25,12 +27,12 @@ class System:  # pylint: disable=too-few-public-methods
 
     async def async_get(self, system_id: int) -> dict:
         """Get a system by ID."""
-        resp = await self._request("get", f"systems/{system_id}")
+        resp: dict = await self._request("get", f"systems/{system_id}")
         return resp["systems"]
 
     async def async_update(self, system_id: int, new_attributes: dict) -> dict:
         """Update a system with a specific attribute payload."""
-        resp = await self._request(
+        resp: dict = await self._request(
             "put", f"systems/{system_id}", json={"systems": new_attributes}
         )
         return resp["systems"]

--- a/aionotion/task.py
+++ b/aionotion/task.py
@@ -3,21 +3,21 @@ from datetime import datetime
 from typing import Callable, List
 
 
-class Task:  # pylint: disable=too-few-public-methods
+class Task:
     """Define an object to interact with all endpoints."""
 
     def __init__(self, request: Callable) -> None:
         """Initialize."""
-        self._request = request
+        self._request: Callable = request
 
     async def async_all(self) -> list:
         """Get all tasks."""
-        resp = await self._request("get", "tasks")
+        resp: dict = await self._request("get", "tasks")
         return resp["tasks"]
 
     async def async_create(self, sensor_id: int, tasks: List[dict]) -> list:
         """Create new tasks based upon a list of attribute dicts."""
-        resp = await self._request(
+        resp: dict = await self._request(
             "post",
             f"sensors/{sensor_id}/tasks",
             json={"sensor_id": sensor_id, "tasks": tasks},
@@ -30,14 +30,14 @@ class Task:  # pylint: disable=too-few-public-methods
 
     async def async_get(self, task_id: str) -> dict:
         """Get a task by ID."""
-        resp = await self._request("get", f"tasks/{task_id}")
+        resp: dict = await self._request("get", f"tasks/{task_id}")
         return resp["tasks"]
 
     async def async_history(
         self, task_id: str, data_before: datetime, data_after: datetime
     ) -> dict:
         """Get the history of a task's values between two datetimes."""
-        resp = await self._request(
+        resp: dict = await self._request(
             "get",
             f"tasks/{task_id}/data",
             params={


### PR DESCRIPTION
**Describe what the PR does:**

Now that we can ensure a minimum of Python 3.6, we can use Python 3.6-style type annotations for variables.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
