### PR TITLE
Remove pre-commit repos from poetry dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,3 +46,8 @@ repos:
     hooks:
       - id: mypy
         files: ^aionotion/.+\.py$
+  - repo: https://github.com/PyCQA/pydocstyle
+    rev: 5.0.2
+    hooks:
+      - id: pydocstyle
+        files: ^((aionotion|tests)/.+)?[^/]+\.py$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,13 +42,7 @@ python = "^3.6.0"
 
 [tool.poetry.dev-dependencies]
 aresponses = "^1.1.1"
-bandit = "^1.6.2"
-black = "^19.10b0"
-flake8 = "^3.7.9"
-mypy = "^0.761"
 pre-commit = "^2.0.1"
-pydocstyle = "^5.0.2"
-pylint = "^2.4.3"
 pytest = "^5.3.5"
 pytest-aiohttp = "^0.3.0"
 pytest-cov = "^2.8.1"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,5 @@
 aiohttp==3.6.2
 aresponses==1.1.2
-pylint==2.4.4
 pytest-aiohttp==0.3.0
 pytest-cov==2.8.1
 pytest==5.3.5


### PR DESCRIPTION
**Describe what the PR does:**

Now that we use `pre-commit` hooks for lots of linting/etc. tasks, we don't need to install those same tools via `script/setup`. This PR makes the necessary changes.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
