### PR TITLE
Make aiohttp ClientSesssion optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,92 +37,90 @@ from aionotion import async_get_client
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
-    async with ClientSession() as session:
-        # Create a Notion API client:
-        client = await async_get_client("<EMAIL>", "<PASSWORD>", session=session)
+    client = await async_get_client("<EMAIL>", "<PASSWORD>", session=session)
 
-        # Get all "households" associated with the account:
-        systems = await client.system.async_all()
+    # Get all "households" associated with the account:
+    systems = await client.system.async_all()
 
-        # Get a system by ID:
-        system = await client.system.async_get(12345)
+    # Get a system by ID:
+    system = await client.system.async_get(12345)
 
-        # Create a system (with associated parameters):
-        await client.system.async_create({"system_id": 12345, "name": "Test"})
+    # Create a system (with associated parameters):
+    await client.system.async_create({"system_id": 12345, "name": "Test"})
 
-        # Update a system with new parameters:
-        await client.system.async_update(12345, {"name": "Test"})
+    # Update a system with new parameters:
+    await client.system.async_update(12345, {"name": "Test"})
 
-        # Delete a system by ID:
-        await client.system.async_delete(12345)
+    # Delete a system by ID:
+    await client.system.async_delete(12345)
 
-        # Get all bridges associated with the account:
-        bridges = await client.bridge.async_all()
+    # Get all bridges associated with the account:
+    bridges = await client.bridge.async_all()
 
-        # Get a bridge by ID:
-        bridge = await client.bridge.async_get(12345)
+    # Get a bridge by ID:
+    bridge = await client.bridge.async_get(12345)
 
-        # Create a bridge (with associated parameters):
-        await client.bridge.async_create({"system_id": 12345, "name": "Test"})
+    # Create a bridge (with associated parameters):
+    await client.bridge.async_create({"system_id": 12345, "name": "Test"})
 
-        # Update a bridge with new parameters:
-        await client.bridge.async_update(12345, {"name": "Test"})
+    # Update a bridge with new parameters:
+    await client.bridge.async_update(12345, {"name": "Test"})
 
-        # Reset a bridge (deprovision its WiFi credentials):
-        await client.bridge.async_reset(12345)
+    # Reset a bridge (deprovision its WiFi credentials):
+    await client.bridge.async_reset(12345)
 
-        # Delete a bridge by ID:
-        await client.bridge.async_delete(12345)
+    # Delete a bridge by ID:
+    await client.bridge.async_delete(12345)
 
-        # Get all devices associated with the account:
-        devices = await client.device.async_all()
+    # Get all devices associated with the account:
+    devices = await client.device.async_all()
 
-        # Get a device by ID:
-        device = await client.device.async_get(12345)
+    # Get a device by ID:
+    device = await client.device.async_get(12345)
 
-        # Create a device (with associated parameters):
-        await client.device.async_create({"id": 12345})
+    # Create a device (with associated parameters):
+    await client.device.async_create({"id": 12345})
 
-        # Delete a device by ID:
-        await client.device.async_delete(12345)
+    # Delete a device by ID:
+    await client.device.async_delete(12345)
 
-        # Get all sensors:
-        sensors = await client.sensor.async_all()
+    # Get all sensors:
+    sensors = await client.sensor.async_all()
 
-        # Get a sensor by ID:
-        sensor = await client.sensor.async_get(12345)
+    # Get a sensor by ID:
+    sensor = await client.sensor.async_get(12345)
 
-        # Create a sensor (with associated parameters):
-        await client.sensor.async_create({"sensor_id": 12345, "name": "Test"})
+    # Create a sensor (with associated parameters):
+    await client.sensor.async_create({"sensor_id": 12345, "name": "Test"})
 
-        # Update a sensor with new parameters:
-        await client.sensor.async_update(12345, {"name": "Test"})
+    # Update a sensor with new parameters:
+    await client.sensor.async_update(12345, {"name": "Test"})
 
-        # Delete a sensor by ID:
-        await client.sensor.async_delete(12345)
+    # Delete a sensor by ID:
+    await client.sensor.async_delete(12345)
 
-        # Get all "tasks" (conditions monitored by sensors) associated with the account:
-        tasks = await client.task.async_all()
+    # Get all "tasks" (conditions monitored by sensors) associated with the account:
+    tasks = await client.task.async_all()
 
-        # Get a task by ID:
-        task = await client.task.async_get("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+    # Get a task by ID:
+    task = await client.task.async_get("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
 
-        # Get a task's value history between two datetimes:
-        import datetime
+    # Get a task's value history between two datetimes:
+    import datetime
 
-        history = await client.task.async_history(
-            "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-            data_before=datetime.datetime.now(),
-            data_after=datetime.datetime.now() - datetime.timedelta(days=3),
-        )
+    history = await client.task.async_history(
+        "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        data_before=datetime.datetime.now(),
+        data_after=datetime.datetime.now() - datetime.timedelta(days=3),
+    )
 
-        # Create a list of tasks for a particular sensor (e.g., sensor # 12345):
-        await client.task.async_create(
-            12345, [{"id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", "type": "missing"}]
-        )
+    # Create a list of tasks for a particular sensor (e.g., sensor # 12345):
+    await client.task.async_create(
+        12345, [{"id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", "type": "missing"}]
+    )
 
-        # Delete a task for a particular sensor (e.g., sensor # 12345):
-        await client.task.async_delete(12345, "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
+    # Delete a task for a particular sensor (e.g., sensor # 12345):
+    await client.task.async_delete(12345, "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
 
 
 asyncio.run(main())

--- a/README.md
+++ b/README.md
@@ -27,26 +27,6 @@ pip install aionotion
 
 # Usage
 
-`aionotion` starts within an
-[aiohttp](https://aiohttp.readthedocs.io/en/stable/) `ClientSession`:
-
-```python
-import asyncio
-
-from aiohttp import ClientSession
-
-
-async def main() -> None:
-    """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
-        # YOUR CODE HERE
-
-
-asyncio.get_event_loop().run_until_complete(main())
-```
-
-Create a client and get to work:
-
 ```python
 import asyncio
 
@@ -57,9 +37,9 @@ from aionotion import async_get_client
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
+    async with ClientSession() as session:
         # Create a Notion API client:
-        client = await async_get_client("<EMAIL>", "<PASSWORD>", websession)
+        client = await async_get_client("<EMAIL>", "<PASSWORD>", session=session)
 
         # Get all "households" associated with the account:
         systems = await client.system.async_all()
@@ -145,7 +125,33 @@ async def main() -> None:
         await client.task.async_delete(12345, "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())
+```
+
+By default, the library creates a new connection to Notion with each coroutine. If you
+are calling a large number of coroutines (or merely want to squeeze out every second of
+runtime savings possible), an
+[`aiohttp`](https://github.com/aio-libs/aiohttp) `ClientSession` can be used for connection
+pooling:
+
+```python
+import asyncio
+
+from aiohttp import ClientSession
+
+from aionotion import async_get_client
+
+
+async def main() -> None:
+    """Create the aiohttp session and run the example."""
+    async with ClientSession() as session:
+        # Create a Notion API client:
+        client = await async_get_client("<EMAIL>", "<PASSWORD>", session=session)
+
+        # Get to work...
+
+
+asyncio.run(main())
 ```
 
 Check out the examples, the tests, and the source files themselves for method

--- a/examples/test_api.py
+++ b/examples/test_api.py
@@ -18,7 +18,7 @@ async def main() -> None:
     logging.basicConfig(level=logging.INFO)
     async with ClientSession() as session:
         try:
-            client = await async_get_client(EMAIL, PASSWORD, session)
+            client = await async_get_client(EMAIL, PASSWORD, session=session)
 
             bridges = await client.bridge.async_all()
             _LOGGER.info("BRIDGES: %s", bridges)
@@ -35,4 +35,4 @@ async def main() -> None:
             _LOGGER.error("There was an error: %s", err)
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,6 @@ python = "^3.6.0"
 [tool.poetry.dev-dependencies]
 aresponses = "^2.0.0"
 pre-commit = "^2.0.1"
-pytest = "^5.3.5"
+pytest = "^5.4.1"
 pytest-aiohttp = "^0.3.0"
 pytest-cov = "^2.8.1"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,4 +2,4 @@ aiohttp==3.6.2
 aresponses==1.1.2
 pytest-aiohttp==0.3.0
 pytest-cov==2.8.1
-pytest==5.3.5
+pytest==5.4.1

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -25,8 +25,8 @@ async def test_bridge_all(aresponses):
         aresponses.Response(text=load_fixture("bridge_all_response.json"), status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         bridges = await client.bridge.async_all()
         assert len(bridges) == 1
 
@@ -51,8 +51,8 @@ async def test_bridge_create(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         create_resp = await client.bridge.async_create(
             {"name": "New Bridge", "system_id": 98765}
         )
@@ -78,8 +78,8 @@ async def test_bridge_delete(aresponses):
         aresponses.Response(text=None, status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         await client.bridge.async_delete(12345)
 
 
@@ -101,8 +101,8 @@ async def test_bridge_get(aresponses):
         aresponses.Response(text=load_fixture("bridge_get_response.json"), status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         bridge = await client.bridge.async_get(12345)
         assert bridge["id"] == 12345
         assert bridge["name"] == "My Bridge"
@@ -128,8 +128,8 @@ async def test_bridge_reset(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         reset_resp = await client.bridge.async_reset(12345)
         assert reset_resp["id"] == 12345
         assert reset_resp["name"] == "My Bridge"
@@ -155,8 +155,8 @@ async def test_bridge_update(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         reset_resp = await client.bridge.async_update(
             12345, {"name": "My Updated Name"}
         )

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -25,8 +25,8 @@ async def test_device_all(aresponses):
         aresponses.Response(text=load_fixture("device_all_response.json"), status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         devices = await client.device.async_all()
         assert len(devices) == 1
 
@@ -51,8 +51,8 @@ async def test_device_create(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         create_resp = await client.device.async_create({"id": 12345})
         assert create_resp["id"] == 12345
         assert create_resp["token"] == "123456abcde"
@@ -76,8 +76,8 @@ async def test_device_delete(aresponses):
         aresponses.Response(text=None, status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         await client.device.async_delete(12345)
 
 
@@ -99,8 +99,8 @@ async def test_device_get(aresponses):
         aresponses.Response(text=load_fixture("device_get_response.json"), status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         device = await client.device.async_get(12345)
         assert device["id"] == 12345
         assert device["token"] == "123456abcde"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -25,8 +25,8 @@ async def test_sensor_all(aresponses):
         aresponses.Response(text=load_fixture("sensor_all_response.json"), status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         sensors = await client.sensor.async_all()
         assert len(sensors) == 2
 
@@ -51,8 +51,8 @@ async def test_sensor_create(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         create_resp = await client.sensor.async_create(
             {"name": "New Sensor", "id": 123456}
         )
@@ -78,8 +78,8 @@ async def test_sensor_delete(aresponses):
         aresponses.Response(text=None, status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         await client.sensor.async_delete(123456)
 
 
@@ -101,8 +101,8 @@ async def test_sensor_get(aresponses):
         aresponses.Response(text=load_fixture("sensor_get_response.json"), status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         sensor = await client.sensor.async_get(123456)
         assert sensor["id"] == 123456
         assert sensor["name"] == "Bathroom Sensor"
@@ -128,8 +128,8 @@ async def test_sensor_update(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         reset_resp = await client.sensor.async_update(
             123456, {"name": "Updated Sensor Name"}
         )

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -25,8 +25,8 @@ async def test_system_all(aresponses):
         aresponses.Response(text=load_fixture("system_all_response.json"), status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         systems = await client.system.async_all()
         assert len(systems) == 1
 
@@ -51,8 +51,8 @@ async def test_system_create(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         create_resp = await client.system.async_create(
             {"name": "New System", "id": 12345}
         )
@@ -78,8 +78,8 @@ async def test_system_delete(aresponses):
         aresponses.Response(text=None, status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         await client.system.async_delete(12345)
 
 
@@ -101,8 +101,8 @@ async def test_system_get(aresponses):
         aresponses.Response(text=load_fixture("system_get_response.json"), status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         system = await client.system.async_get(12345)
         assert system["id"] == 12345
         assert system["name"] == "Home"
@@ -128,8 +128,8 @@ async def test_system_update(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         reset_resp = await client.system.async_update(
             12345, {"name": "Updated System Name"}
         )

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -27,8 +27,8 @@ async def test_task_all(aresponses):
         aresponses.Response(text=load_fixture("task_all_response.json"), status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         tasks = await client.task.async_all()
         assert len(tasks) == 7
 
@@ -51,8 +51,8 @@ async def test_task_create(aresponses):
         aresponses.Response(text=load_fixture("task_create_response.json"), status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         create_resp = await client.task.async_create(
             12345, [{"id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", "type": "missing"}]
         )
@@ -78,8 +78,8 @@ async def test_task_delete(aresponses):
         aresponses.Response(text=None, status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         await client.task.async_delete(12345, "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
 
 
@@ -101,8 +101,8 @@ async def test_task_get(aresponses):
         aresponses.Response(text=load_fixture("task_get_response.json"), status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         task = await client.task.async_get("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
         assert task["id"] == "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
         assert task["task_type"] == "missing"
@@ -128,8 +128,8 @@ async def test_task_history(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
         history = await client.task.async_history(
             "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
             data_before=datetime.datetime.now(),


### PR DESCRIPTION
**Describe what the PR does:**

This PR makes the `aiohttp` `ClientSession` an optional parameter when creating an API object.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
