### PR TITLE
Relax `Bridge` model to allow `name` to be `None`

### DIFF
--- a/aionotion/bridge/models.py
+++ b/aionotion/bridge/models.py
@@ -22,7 +22,7 @@ class Bridge(BaseModel):
     """Define a bridge."""
 
     id: int
-    name: str
+    name: str | None
     mode: str
     hardware_id: str
     hardware_revision: int

--- a/aionotion/bridge/models.py
+++ b/aionotion/bridge/models.py
@@ -22,7 +22,7 @@ class Bridge(BaseModel):
     """Define a bridge."""
 
     id: int
-    name: str | None
+    name: Optional[str]
     mode: str
     hardware_id: str
     hardware_revision: int

--- a/tests/fixtures/bridge_all_response.json
+++ b/tests/fixtures/bridge_all_response.json
@@ -2,7 +2,7 @@
   "base_stations": [
     {
       "id": 12345,
-      "name": "Bridge 1",
+      "name": null,
       "mode": "home",
       "hardware_id": "0x0000000000000000",
       "hardware_revision": 4,

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -41,7 +41,7 @@ async def test_bridge_all(
             assert len(bridges) == 2
 
             assert bridges[0].id == 12345
-            assert bridges[0].name == "Bridge 1"
+            assert bridges[0].name is None
             assert bridges[0].mode == "home"
             assert bridges[0].hardware_id == "0x0000000000000000"
             assert bridges[0].hardware_revision == 4


### PR DESCRIPTION
**Describe what the PR does:**

Per a Home Assistant user, bridges/base stations can apparently have `None` for their name—this PR relaxes the Pydantic validation appropriately.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
