### PR TITLE
Make several sensor datetimes optional

### DIFF
--- a/aionotion/sensor/models.py
+++ b/aionotion/sensor/models.py
@@ -56,9 +56,9 @@ class Sensor(BaseModel):
     firmware_version: str
     device_key: str
     encryption_key: bool
-    installed_at: datetime
-    calibrated_at: datetime
-    last_reported_at: datetime
+    installed_at: Optional[datetime]
+    calibrated_at: Optional[datetime]
+    last_reported_at: Optional[datetime]
     missing_at: Optional[datetime]
     updated_at: datetime
     created_at: datetime

--- a/tests/fixtures/sensor_all_response.json
+++ b/tests/fixtures/sensor_all_response.json
@@ -21,7 +21,7 @@
       "device_key": "0x0000000000000000",
       "encryption_key": true,
       "installed_at": "2019-06-28T22:12:51.209Z",
-      "calibrated_at": "2023-03-07T19:51:56.838Z",
+      "calibrated_at": null,
       "last_reported_at": "2023-04-19T18:09:40.479Z",
       "missing_at": null,
       "updated_at": "2023-03-28T13:33:33.801Z",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -60,9 +60,7 @@ async def test_sensor_all(
             assert sensors[0].installed_at == datetime(
                 2019, 6, 28, 22, 12, 51, 209000, tzinfo=timezone.utc
             )
-            assert sensors[0].calibrated_at == datetime(
-                2023, 3, 7, 19, 51, 56, 838000, tzinfo=timezone.utc
-            )
+            assert sensors[0].calibrated_at is None
             assert sensors[0].last_reported_at == datetime(
                 2023, 4, 19, 18, 9, 40, 479000, tzinfo=timezone.utc
             )


### PR DESCRIPTION
**Describe what the PR does:**

Per [a Home Assistant report](https://github.com/home-assistant/core/issues/92692), sensors may have `None` for `calibrated_at`. Given this, I also think it's possible that `last_reported_at`, `missing_at`, and `installed_at` might act similarly. Therefore, this PR relaxes the requirement that they exist.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
