### PR TITLE
Remove Safety as a dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -490,25 +490,6 @@ files = [
 ]
 
 [[package]]
-name = "dparse"
-version = "0.6.3"
-description = "A parser for Python dependency files"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "dparse-0.6.3-py3-none-any.whl", hash = "sha256:0d8fe18714056ca632d98b24fbfc4e9791d4e47065285ab486182288813a5318"},
-    {file = "dparse-0.6.3.tar.gz", hash = "sha256:27bb8b4bcaefec3997697ba3f6e06b2447200ba273c0b085c3d012a04571b528"},
-]
-
-[package.dependencies]
-packaging = "*"
-tomli = {version = "*", markers = "python_version < \"3.11\""}
-
-[package.extras]
-conda = ["pyyaml"]
-pipenv = ["pipenv (<=2022.12.19)"]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.1.3"
 description = "Backport of PEP 654 (exception groups)"
@@ -1397,29 +1378,6 @@ files = [
 ]
 
 [[package]]
-name = "safety"
-version = "2.3.4"
-description = "Checks installed dependencies for known vulnerabilities and licenses."
-optional = false
-python-versions = "*"
-files = [
-    {file = "safety-2.3.4-py3-none-any.whl", hash = "sha256:6224dcd9b20986a2b2c5e7acfdfba6bca42bb11b2783b24ed04f32317e5167ea"},
-    {file = "safety-2.3.4.tar.gz", hash = "sha256:b9e74e794e82f54d11f4091c5d820c4d2d81de9f953bf0b4f33ac8bc402ae72c"},
-]
-
-[package.dependencies]
-Click = ">=8.0.2"
-dparse = ">=0.6.2"
-packaging = ">=21.0"
-requests = "*"
-"ruamel.yaml" = ">=0.17.21"
-setuptools = ">=19.3"
-
-[package.extras]
-github = ["jinja2 (>=3.1.0)", "pygithub (>=1.43.3)"]
-gitlab = ["python-gitlab (>=1.3.0)"]
-
-[[package]]
 name = "setuptools"
 version = "68.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -1676,4 +1634,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "ea3b832cc25f1e4e247deef2d25f921038e2e60f59c77611142bb285ad7c1c2c"
+content-hash = "5909012e0953fdca4a7c8c453699037411842a14bfe36069676b9c6b1b47ea0e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,6 @@ pyupgrade = "^3.1.0"
 pyyaml = "^6.0.1"
 requests = ">=2.31.0"
 ruff = ">=0.0.261,<0.1.14"
-safety = "^2.3.1"
 vulture = "^2.6"
 yamllint = "^1.28.0"
 


### PR DESCRIPTION
**Describe what the PR does:**

We aren't actively using Safety, and we have to [pay](https://safetycli.com/resources/plans) for it to use it in CI/CD. [GitHub CodeQL](https://codeql.github.com/) effectively does the same thing.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
