### PR TITLE
Add the ability to define refresh token callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,40 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+## Refresh Token Callbacks
+
+`aionotion` allows implementers to defining callbacks that get called when a new refresh
+token is generated. These callbacks accept a single string parameter (the refresh
+token):
+
+```python
+import asyncio
+
+from aiohttp import ClientSession
+
+from aionotion import async_get_client
+
+
+async def main() -> None:
+    """Create the aiohttp session and run the example."""
+    client = await async_get_client("<EMAIL>", "<PASSWORD>", session=session)
+
+    def do_somethng_with_refresh_token(refresh_token: str) -> None:
+        """Do something interesting."""
+        pass
+
+    # Attach the callback to the client:
+    remove_callback = client.add_refresh_token_callback(do_somethng_with_refresh_token)
+
+    # Later, if you want to remove the callback:
+    remove_callback()
+
+
+asyncio.run(main())
+```
+
+## Connection Pooling
+
 By default, the library creates a new connection to Notion with each coroutine. If you
 are calling a large number of coroutines (or merely want to squeeze out every second of
 runtime savings possible), an [`aiohttp`][aiohttp] `ClientSession` can be used for

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -309,6 +309,7 @@ async def test_refresh_token_callback(
 
         # Cancel the callback and refresh the access token again:
         remove_callback()
+        await client.async_authenticate_from_refresh_token()
 
         # Ensure that the callback was called only once:
         refresh_token_callback.assert_called_once_with(client._refresh_token)


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds the ability to call callbacks when a new refresh token is generated.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
