### PR TITLE
Add ability to create a client from a refresh token

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,22 @@ import asyncio
 
 from aiohttp import ClientSession
 
-from aionotion import async_get_client
+from aionotion import async_get_client_with_credentials
 
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
-    client = await async_get_client("<EMAIL>", "<PASSWORD>", session=session)
+    client = await async_get_client_with_credentials(
+        "<EMAIL>", "<PASSWORD>", session=session
+    )
+
+    # Get the UUID of the authenticated user:
+    client.user_uuid
+    # >>> xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+
+    # Get the current refresh token of the authenticated user (BE CAREFUL):
+    client.refresh_token
+    # >>> abcde12345
 
     # Get all "households" associated with the account:
     systems = await client.system.async_all()
@@ -89,7 +99,13 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-## Refresh Token Callbacks
+## Using a Refresh Token
+
+During the normal course of operations, `aionotion` will automatically maintain a refresh
+token and use it when needed. At times, you may wish to manage that token yourself (so
+that you can use it later)–`aionotion` provides a few useful capabilities there.
+
+### Refresh Token Callbacks
 
 `aionotion` allows implementers to defining callbacks that get called when a new refresh
 token is generated. These callbacks accept a single string parameter (the refresh
@@ -100,12 +116,14 @@ import asyncio
 
 from aiohttp import ClientSession
 
-from aionotion import async_get_client
+from aionotion import async_get_client_with_credentials
 
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
-    client = await async_get_client("<EMAIL>", "<PASSWORD>", session=session)
+    client = await async_get_client_with_credentials(
+        "<EMAIL>", "<PASSWORD>", session=session
+    )
 
     def do_somethng_with_refresh_token(refresh_token: str) -> None:
         """Do something interesting."""
@@ -116,6 +134,34 @@ async def main() -> None:
 
     # Later, if you want to remove the callback:
     remove_callback()
+
+
+asyncio.run(main())
+```
+
+### Getting a Client via a Refresh Token
+
+All of previous examples retrieved an authenticated client with
+`async_get_client_with_credentials`. However, implementers may also create an
+authenticated client by providing a previously retrieved user UUID and refresh token:
+
+```python
+import asyncio
+
+from aiohttp import ClientSession
+
+from aionotion import async_get_client_with_refresh_token
+
+
+async def main() -> None:
+    """Create the aiohttp session and run the example."""
+    async with ClientSession() as session:
+        # Create a Notion API client:
+        client = await async_get_client_with_refresh_token(
+            "<USER UUID>", "<REFRESH TOKEN>", session=session
+        )
+
+        # Get to work...
 
 
 asyncio.run(main())
@@ -133,14 +179,16 @@ import asyncio
 
 from aiohttp import ClientSession
 
-from aionotion import async_get_client
+from aionotion import async_get_client_with_credentials
 
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
     async with ClientSession() as session:
         # Create a Notion API client:
-        client = await async_get_client("<EMAIL>", "<PASSWORD>", session=session)
+        client = await async_get_client_with_credentials(
+            "<EMAIL>", "<PASSWORD>", session=session
+        )
 
         # Get to work...
 

--- a/aionotion/__init__.py
+++ b/aionotion/__init__.py
@@ -1,2 +1,4 @@
 """Define the aionotion package."""
-from .client import async_get_client  # noqa
+from .client import async_get_client  # noqa: F401
+from .client import async_get_client_with_credentials  # noqa: F401
+from .client import async_get_client_with_refresh_token  # noqa: F401

--- a/aionotion/client.py
+++ b/aionotion/client.py
@@ -276,7 +276,7 @@ class Client:
         if not use_running_session:
             await session.close()
 
-        LOGGER.debug("Received data from /%s: %s", endpoint, data)
+        LOGGER.debug("Received data from %s: %s", endpoint, data)
 
         if self._refreshing_access_token:
             self._refreshing_access_token = False
@@ -315,7 +315,7 @@ class Client:
             ) from err
 
 
-async def async_get_client(
+async def async_get_client_with_credentials(
     email: str,
     password: str,
     *,
@@ -323,7 +323,7 @@ async def async_get_client(
     session_name: str | None = None,
     use_legacy_auth: bool = False,
 ) -> Client:
-    """Return an authenticated API object.
+    """Return an authenticated API object (using username/password)
 
     Args:
         email: The email address of a Notion account.
@@ -340,4 +340,32 @@ async def async_get_client(
         await client.async_legacy_authenticate_from_credentials(email, password)
     else:
         await client.async_authenticate_from_credentials(email, password)
+    return client
+
+
+# Alias for backwards compatibility:
+async_get_client = async_get_client_with_credentials
+
+
+async def async_get_client_with_refresh_token(
+    user_uuid: str,
+    refresh_token: str,
+    *,
+    session: ClientSession | None = None,
+    session_name: str | None = None,
+) -> Client:
+    """Return an authenticated API object (using a refresh token).
+
+    Args:
+        user_uuid: The UUID of the user.
+        refresh_token: A refresh token.
+        session: An optional aiohttp ClientSession.
+        session_name: An optional session name to use for authentication.
+
+    Returns:
+        An authenticated Client object.
+    """
+    client = Client(session=session, session_name=session_name)
+    client.user_uuid = user_uuid
+    await client.async_authenticate_from_refresh_token(refresh_token=refresh_token)
     return client

--- a/examples/test_api.py
+++ b/examples/test_api.py
@@ -5,7 +5,7 @@ import os
 
 from aiohttp import ClientSession
 
-from aionotion import async_get_client
+from aionotion import async_get_client_with_credentials
 from aionotion.errors import NotionError
 
 _LOGGER = logging.getLogger()
@@ -27,7 +27,9 @@ async def main() -> None:
 
     async with ClientSession() as session:
         try:
-            client = await async_get_client(EMAIL, PASSWORD, session=session)
+            client = await async_get_client_with_credentials(
+                EMAIL, PASSWORD, session=session
+            )
 
             bridges = await client.bridge.async_all()
             _LOGGER.info("BRIDGES: %s", bridges)

--- a/tests/common.py
+++ b/tests/common.py
@@ -6,6 +6,7 @@ import jwt
 
 TEST_EMAIL = "user@email.com"
 TEST_PASSWORD = "password123"  # noqa: S105
+TEST_REFRESH_TOKEN = "abcde12345"
 TEST_USER_UUID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
 

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -8,7 +8,7 @@ import aiohttp
 import pytest
 from aresponses import ResponsesMockServer
 
-from aionotion import async_get_client
+from aionotion import async_get_client_with_credentials
 from tests.common import TEST_EMAIL, TEST_PASSWORD
 
 
@@ -36,7 +36,9 @@ async def test_bridge_all(
         )
 
         async with aiohttp.ClientSession() as session:
-            client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
+            client = await async_get_client_with_credentials(
+                TEST_EMAIL, TEST_PASSWORD, session=session
+            )
             bridges = await client.bridge.async_all()
             assert len(bridges) == 1
             assert bridges[0].id == 12345
@@ -88,7 +90,9 @@ async def test_bridge_get(
         )
 
         async with aiohttp.ClientSession() as session:
-            client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
+            client = await async_get_client_with_credentials(
+                TEST_EMAIL, TEST_PASSWORD, session=session
+            )
             bridge = await client.bridge.async_get(12345)
             assert bridge.id == 12345
             assert bridge.name == "Laundry Closet"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
 from time import time
 from typing import Any
 from unittest.mock import Mock
@@ -12,11 +11,14 @@ import aiohttp
 import pytest
 from aresponses import ResponsesMockServer
 
-from aionotion import async_get_client
+from aionotion import (
+    async_get_client_with_credentials,
+    async_get_client_with_refresh_token,
+)
 from aionotion.client import Client
 from aionotion.errors import InvalidCredentialsError, RequestError
 
-from .common import TEST_EMAIL, TEST_PASSWORD, TEST_USER_UUID
+from .common import TEST_EMAIL, TEST_PASSWORD, TEST_REFRESH_TOKEN, TEST_USER_UUID
 
 
 @pytest.mark.asyncio
@@ -42,7 +44,7 @@ async def test_api_error(
 
         async with aiohttp.ClientSession() as session:
             with pytest.raises(RequestError):
-                client = await async_get_client(
+                client = await async_get_client_with_credentials(
                     TEST_EMAIL, TEST_PASSWORD, session=session
                 )
                 await client.async_request("get", "/bad_endpoint")
@@ -62,7 +64,9 @@ async def test_auth_credentials_success(
         authenticated_notion_api_server: A mock authenticated Notion API server
     """
     async with authenticated_notion_api_server, aiohttp.ClientSession() as session:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
+        client = await async_get_client_with_credentials(
+            TEST_EMAIL, TEST_PASSWORD, session=session
+        )
         assert client._access_token is not None
 
     aresponses.assert_plan_strictly_followed()
@@ -87,7 +91,9 @@ async def test_auth_failure(
 
     async with aiohttp.ClientSession() as session:
         with pytest.raises(InvalidCredentialsError):
-            _ = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
+            _ = await async_get_client_with_credentials(
+                TEST_EMAIL, TEST_PASSWORD, session=session
+            )
 
     aresponses.assert_plan_strictly_followed()
 
@@ -121,41 +127,48 @@ async def test_auth_legacy_credentials_success(
     )
 
     async with aiohttp.ClientSession() as session:
-        client = await async_get_client(
+        client = await async_get_client_with_credentials(
             TEST_EMAIL, TEST_PASSWORD, session=session, use_legacy_auth=True
         )
         assert client._access_token is not None
 
         bridges = await client.bridge.async_all()
         assert len(bridges) == 1
-        assert bridges[0].id == 12345
-        assert bridges[0].name == "Laundry Closet"
-        assert bridges[0].mode == "home"
-        assert bridges[0].hardware_id == "0x0000000000000000"
-        assert bridges[0].hardware_revision == 4
-        assert bridges[0].firmware_version.silabs == "1.1.2"
-        assert bridges[0].firmware_version.wifi == "0.121.0"
-        assert bridges[0].firmware_version.wifi_app == "3.3.0"
-        assert bridges[0].missing_at is None
-        assert bridges[0].created_at == datetime(
-            2019, 4, 30, 1, 43, 50, 497000, tzinfo=timezone.utc
+
+    aresponses.assert_plan_strictly_followed()
+
+
+@pytest.mark.asyncio
+async def test_auth_refresh_token_success(
+    aresponses: ResponsesMockServer,
+    auth_refresh_token_success_response: dict[str, Any],
+) -> None:
+    """Test authenticating against the API with credentials.
+
+    Args:
+        aresponses: An aresponses server.
+        auth_refresh_token_success_response: An API response payload
+    """
+    aresponses.add(
+        "api.getnotion.com",
+        f"/api/auth/{TEST_USER_UUID}/refresh",
+        "post",
+        response=aiohttp.web_response.json_response(
+            auth_refresh_token_success_response, status=200
+        ),
+    )
+    async with aiohttp.ClientSession() as session:
+        client = await async_get_client_with_refresh_token(
+            TEST_USER_UUID, TEST_REFRESH_TOKEN, session=session
         )
-        assert bridges[0].updated_at == datetime(
-            2023, 12, 12, 22, 33, 1, 73000, tzinfo=timezone.utc
-        )
-        assert bridges[0].system_id == 12345
-        assert bridges[0].firmware.silabs == "1.1.2"
-        assert bridges[0].firmware.ti is None
-        assert bridges[0].firmware.wifi == "0.121.0"
-        assert bridges[0].firmware.wifi_app == "3.3.0"
-        assert bridges[0].links["system"] == 12345
+        assert client._access_token is not None
 
     aresponses.assert_plan_strictly_followed()
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("refresh_token", [None, "new_refresh_token"])
-async def test_auth_refresh_token_success(
+async def test_auth_refresh_token_success_existing_client(
     aresponses: ResponsesMockServer,
     authenticated_notion_api_server: ResponsesMockServer,
     refresh_token: str | None,
@@ -168,7 +181,9 @@ async def test_auth_refresh_token_success(
         refresh_token: An optional refresh token
     """
     async with authenticated_notion_api_server, aiohttp.ClientSession() as session:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
+        client = await async_get_client_with_credentials(
+            TEST_EMAIL, TEST_PASSWORD, session=session
+        )
         old_access_token = client._access_token
         assert old_access_token is not None
         assert client.refresh_token is not None
@@ -209,33 +224,13 @@ async def test_expired_access_token(
             ),
         )
 
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
-        bridges = await client.bridge.async_all()
+        client = await async_get_client_with_credentials(
+            TEST_EMAIL, TEST_PASSWORD, session=session
+        )
+        _ = await client.bridge.async_all()
         assert any(
             m for m in caplog.messages if "Access token expired, refreshing..." in m
         )
-        assert len(bridges) == 1
-        assert bridges[0].id == 12345
-        assert bridges[0].name == "Laundry Closet"
-        assert bridges[0].mode == "home"
-        assert bridges[0].hardware_id == "0x0000000000000000"
-        assert bridges[0].hardware_revision == 4
-        assert bridges[0].firmware_version.silabs == "1.1.2"
-        assert bridges[0].firmware_version.wifi == "0.121.0"
-        assert bridges[0].firmware_version.wifi_app == "3.3.0"
-        assert bridges[0].missing_at is None
-        assert bridges[0].created_at == datetime(
-            2019, 4, 30, 1, 43, 50, 497000, tzinfo=timezone.utc
-        )
-        assert bridges[0].updated_at == datetime(
-            2023, 12, 12, 22, 33, 1, 73000, tzinfo=timezone.utc
-        )
-        assert bridges[0].system_id == 12345
-        assert bridges[0].firmware.silabs == "1.1.2"
-        assert bridges[0].firmware.ti is None
-        assert bridges[0].firmware.wifi == "0.121.0"
-        assert bridges[0].firmware.wifi_app == "3.3.0"
-        assert bridges[0].links["system"] == 12345
 
     aresponses.assert_plan_strictly_followed()
 
@@ -271,7 +266,7 @@ async def test_no_explicit_session(
         authenticated_notion_api_server: A mock authenticated Notion API server
     """
     async with authenticated_notion_api_server:
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD)
+        client = await async_get_client_with_credentials(TEST_EMAIL, TEST_PASSWORD)
         assert client._access_token is not None
 
     aresponses.assert_plan_strictly_followed()
@@ -300,7 +295,7 @@ async def test_refresh_token_callback(
             ),
         )
 
-        client = await async_get_client(TEST_EMAIL, TEST_PASSWORD)
+        client = await async_get_client_with_credentials(TEST_EMAIL, TEST_PASSWORD)
         assert client._access_token is not None
 
         # Define and attach a refresh token callback, then refresh the access token:
@@ -341,6 +336,8 @@ async def test_validation_error(
         )
 
         async with aiohttp.ClientSession() as session:
-            client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
+            client = await async_get_client_with_credentials(
+                TEST_EMAIL, TEST_PASSWORD, session=session
+            )
             with pytest.raises(RequestError):
                 await client.bridge.async_get(98765)

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -8,7 +8,7 @@ import aiohttp
 import pytest
 from aresponses import ResponsesMockServer
 
-from aionotion import async_get_client
+from aionotion import async_get_client_with_credentials
 from tests.common import TEST_EMAIL, TEST_PASSWORD
 
 
@@ -36,7 +36,9 @@ async def test_listener_all(
         )
 
         async with aiohttp.ClientSession() as session:
-            client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
+            client = await async_get_client_with_credentials(
+                TEST_EMAIL, TEST_PASSWORD, session=session
+            )
             listeners = await client.listener.async_all()
             assert len(listeners) == 1
             assert listeners[0].id == "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
@@ -87,7 +89,9 @@ async def test_listener_definitions(
         )
 
         async with aiohttp.ClientSession() as session:
-            client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
+            client = await async_get_client_with_credentials(
+                TEST_EMAIL, TEST_PASSWORD, session=session
+            )
             definitions = await client.listener.async_definitions()
             assert len(definitions) == 20
             assert definitions[0].id == 0

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -8,7 +8,7 @@ import aiohttp
 import pytest
 from aresponses import ResponsesMockServer
 
-from aionotion import async_get_client
+from aionotion import async_get_client_with_credentials
 from tests.common import TEST_EMAIL, TEST_PASSWORD
 
 
@@ -36,7 +36,9 @@ async def test_sensor_all(
         )
 
         async with aiohttp.ClientSession() as session:
-            client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
+            client = await async_get_client_with_credentials(
+                TEST_EMAIL, TEST_PASSWORD, session=session
+            )
             sensors = await client.sensor.async_all()
             assert len(sensors) == 1
             assert sensors[0].id == 123456
@@ -104,7 +106,9 @@ async def test_sensor_get(
         )
 
         async with aiohttp.ClientSession() as session:
-            client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
+            client = await async_get_client_with_credentials(
+                TEST_EMAIL, TEST_PASSWORD, session=session
+            )
             sensor = await client.sensor.async_get(123456)
             assert sensor.id == 123456
             assert sensor.uuid == "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -7,7 +7,7 @@ import aiohttp
 import pytest
 from aresponses import ResponsesMockServer
 
-from aionotion import async_get_client
+from aionotion import async_get_client_with_credentials
 
 from .common import TEST_EMAIL, TEST_PASSWORD
 
@@ -36,7 +36,9 @@ async def test_system_all(
         )
 
         async with aiohttp.ClientSession() as session:
-            client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
+            client = await async_get_client_with_credentials(
+                TEST_EMAIL, TEST_PASSWORD, session=session
+            )
             systems = await client.system.async_all()
             assert len(systems) == 1
             assert systems[0].uuid == "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
@@ -95,7 +97,9 @@ async def test_system_get(
         )
 
         async with aiohttp.ClientSession() as session:
-            client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
+            client = await async_get_client_with_credentials(
+                TEST_EMAIL, TEST_PASSWORD, session=session
+            )
             system = await client.system.async_get(12345)
             assert system.uuid == "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
             assert system.name == "Home"

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -8,7 +8,7 @@ import aiohttp
 import pytest
 from aresponses import ResponsesMockServer
 
-from aionotion import async_get_client
+from aionotion import async_get_client_with_credentials
 from tests.common import TEST_EMAIL, TEST_PASSWORD, TEST_USER_UUID
 
 
@@ -32,7 +32,9 @@ async def test_user_info(
         )
 
         async with aiohttp.ClientSession() as session:
-            client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
+            client = await async_get_client_with_credentials(
+                TEST_EMAIL, TEST_PASSWORD, session=session
+            )
             user_info = await client.user.async_info()
             assert user_info.id == 12345
             assert user_info.uuid == "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
@@ -72,7 +74,9 @@ async def test_user_preferences(
         )
 
         async with aiohttp.ClientSession() as session:
-            client = await async_get_client(TEST_EMAIL, TEST_PASSWORD, session=session)
+            client = await async_get_client_with_credentials(
+                TEST_EMAIL, TEST_PASSWORD, session=session
+            )
             user_preferences = await client.user.async_preferences()
             assert user_preferences.user_id == 12345
             assert user_preferences.military_time_enabled is False


### PR DESCRIPTION
**Describe what the PR does:**

SSIA. Note that although the "approved" client creation methods are `async_get_client_with_credentials` and `async_get_client_with_refresh_token`, we leave `async_get_client` in place (as an alias to `async_get_client_with_credentials`) for backward compatibility.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
