### PR TITLE
Fix too-strict model for old-style sensor

### DIFF
--- a/aionotion/listener/models.py
+++ b/aionotion/listener/models.py
@@ -31,10 +31,10 @@ class InsightOrigin(DataClassDictMixin):
 class PrimaryListenerInsight(DataClassDictMixin):
     """Define a primary listener insight."""
 
-    origin: InsightOrigin
-    value: str
-    data_received_at: datetime = field(
-        metadata={"deserialize": ciso8601.parse_datetime}
+    origin: InsightOrigin | None
+    value: str | None
+    data_received_at: datetime | None = field(
+        default=None, metadata={"deserialize": ciso8601.parse_datetime}
     )
 
 

--- a/tests/fixtures/sensor_listeners_response.json
+++ b/tests/fixtures/sensor_listeners_response.json
@@ -13,9 +13,12 @@
       },
       "insights": {
         "primary": {
-          "origin": null,
-          "value": null,
-          "data_received_at": null
+          "origin": {
+            "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+            "type": "Sensor"
+          },
+          "value": "idle",
+          "data_received_at": "2023-06-18T06:17:00.697Z"
         }
       },
       "configuration": {},
@@ -34,12 +37,9 @@
       },
       "insights": {
         "primary": {
-          "origin": {
-            "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-            "type": "Sensor"
-          },
-          "value": "idle",
-          "data_received_at": "2023-06-18T06:17:00.697Z"
+          "origin": null,
+          "value": null,
+          "data_received_at": null
         }
       },
       "configuration": {},

--- a/tests/fixtures/sensor_listeners_response.json
+++ b/tests/fixtures/sensor_listeners_response.json
@@ -13,6 +13,27 @@
       },
       "insights": {
         "primary": {
+          "origin": null,
+          "value": null,
+          "data_received_at": null
+        }
+      },
+      "configuration": {},
+      "pro_monitoring_status": "ineligible"
+    },
+    {
+      "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+      "definition_id": 24,
+      "created_at": "2019-06-17T03:29:45.722Z",
+      "type": "sensor",
+      "model_version": "1.0",
+      "sensor_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+      "status_localized": {
+        "state": "Idle",
+        "description": "Jun 18 at 12:17am"
+      },
+      "insights": {
+        "primary": {
           "origin": {
             "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
             "type": "Sensor"

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -42,7 +42,7 @@ async def test_listener_all(
             )
             listeners = await client.listener.async_all()
             assert len(listeners) == 2
- 
+
             assert listeners[0].id == "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
             assert listeners[0].definition_id == 24
             assert listeners[0].created_at == datetime(

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -41,7 +41,8 @@ async def test_listener_all(
                 TEST_EMAIL, TEST_PASSWORD, session=session
             )
             listeners = await client.listener.async_all()
-            assert len(listeners) == 1
+            assert len(listeners) == 2
+ 
             assert listeners[0].id == "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
             assert listeners[0].definition_id == 24
             assert listeners[0].created_at == datetime(
@@ -63,6 +64,21 @@ async def test_listener_all(
             )
             assert listeners[0].configuration == {}
             assert listeners[0].pro_monitoring_status == "ineligible"
+
+            assert listeners[1].id == "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+            assert listeners[1].definition_id == 24
+            assert listeners[1].created_at == datetime(
+                2019, 6, 17, 3, 29, 45, 722000, tzinfo=timezone.utc
+            )
+            assert listeners[1].device_type == "sensor"
+            assert listeners[1].model_version == "1.0"
+            assert listeners[1].sensor_id == "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+            assert listeners[1].status_localized.state == "Idle"
+            assert listeners[1].insights.primary.origin is None
+            assert listeners[1].insights.primary.value is None
+            assert listeners[1].insights.primary.data_received_at is None
+            assert listeners[1].configuration == {}
+            assert listeners[1].pro_monitoring_status == "ineligible"
 
     aresponses.assert_plan_strictly_followed()
 

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -51,6 +51,7 @@ async def test_listener_all(
             assert listeners[0].model_version == "1.0"
             assert listeners[0].sensor_id == "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
             assert listeners[0].status_localized.state == "Idle"
+            assert listeners[0].insights.primary.origin is not None
             assert (
                 listeners[0].insights.primary.origin.id
                 == "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"


### PR DESCRIPTION
**Describe what the PR does:**

[This bug report](https://github.com/home-assistant/core/issues/112585) showed that older generator sensors have primary insights values that can be `None`. This PR loosens up the appropriate model.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
