### PR TITLE
ci: renovate use of `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,11 +80,6 @@ repos:
         language: system
         types: [text]
         entry: poetry run fix-byte-order-marker
-      - id: isort
-        name: 🔀 Sorting all imports with isort
-        language: system
-        types: [python]
-        entry: poetry run isort
       - id: format
         name: ☕️ Formatting code using ruff
         language: system
@@ -95,8 +90,6 @@ repos:
         language: system
         types: [python]
         entry: poetry run mypy
-        require_serial: true
-        exclude: ^vulture_whitelist.py$
       - id: no-commit-to-branch
         name: 🛑 Checking for commit to protected branch
         language: system
@@ -117,37 +110,17 @@ repos:
         language: system
         types: [python]
         entry: poetry run pylint
-        exclude: ^vulture_whitelist.py$
-      - id: pyupgrade
-        name: 🆙 Checking for upgradable syntax with pyupgrade
-        language: system
-        types: [python]
-        entry: poetry run pyupgrade
-        args: [--py39-plus, --keep-runtime-typing]
       - id: ruff
         name: 👔 Enforcing style guide with ruff
         language: system
         types: [python]
-        entry: poetry run ruff --fix
-        exclude: ^vulture_whitelist.py$
+        entry: poetry run ruff check --fix
       - id: trailing-whitespace
         name: ✄  Trimming trailing whitespace
         language: system
         types: [text]
         entry: poetry run trailing-whitespace-fixer
         stages: [commit, push, manual]
-      - id: vulture
-        name: 🔍 Finding unused Python code with Vulture
-        language: system
-        types: [python]
-        entry: poetry run vulture vulture_whitelist.py
-        pass_filenames: false
-        require_serial: true
-      - id: yamllint
-        name: 🎗  Checking YAML files with yamllint
-        language: system
-        types: [yaml]
-        entry: poetry run yamllint
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.0.0-alpha.4"

--- a/aionotion/__init__.py
+++ b/aionotion/__init__.py
@@ -1,5 +1,7 @@
 """Define the aionotion package."""
 
-from .client import async_get_client  # noqa: F401
-from .client import async_get_client_with_credentials  # noqa: F401
-from .client import async_get_client_with_refresh_token  # noqa: F401
+from .client import (
+    async_get_client,  # noqa: F401
+    async_get_client_with_credentials,  # noqa: F401
+    async_get_client_with_refresh_token,  # noqa: F401
+)

--- a/aionotion/bridge/__init__.py
+++ b/aionotion/bridge/__init__.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from aionotion.bridge.models import Bridge as BridgeModel
-from aionotion.bridge.models import BridgeAllResponse, BridgeGetResponse
+from aionotion.bridge.models import (
+    Bridge as BridgeModel,
+    BridgeAllResponse,
+    BridgeGetResponse,
+)
 
 if TYPE_CHECKING:
     from aionotion.client import Client
@@ -18,15 +21,19 @@ class Bridge:
         """Initialize.
 
         Args:
+        ----
             client: The aionotion client
+
         """
         self._client = client
 
     async def async_all(self) -> list[BridgeModel]:
         """Get all bridges.
 
-        Returns:
+        Returns
+        -------
             A validated API response payload.
+
         """
         response: BridgeAllResponse = await self._client.async_request_and_validate(
             "get", "/base_stations", BridgeAllResponse
@@ -37,10 +44,13 @@ class Bridge:
         """Get a bridge by ID.
 
         Args:
+        ----
             bridge_id: The ID of the bridge to get.
 
         Returns:
+        -------
             A validated API response payload.
+
         """
         response: BridgeGetResponse = await self._client.async_request_and_validate(
             "get", f"/base_stations/{bridge_id}", BridgeGetResponse

--- a/aionotion/errors.py
+++ b/aionotion/errors.py
@@ -4,16 +4,10 @@
 class NotionError(Exception):
     """Define a base error."""
 
-    pass
-
 
 class RequestError(NotionError):
     """Define an error related to invalid requests."""
 
-    pass
-
 
 class InvalidCredentialsError(NotionError):
     """Define an error for unauthenticated accounts."""
-
-    pass

--- a/aionotion/listener/__init__.py
+++ b/aionotion/listener/__init__.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from aionotion.listener.models import Listener as ListenerModel
 from aionotion.listener.models import (
+    Listener as ListenerModel,
     ListenerAllResponse,
     ListenerDefinition,
     ListenerDefinitionResponse,
@@ -22,15 +22,19 @@ class Listener:
         """Initialize.
 
         Args:
+        ----
             client: The aionotion client
+
         """
         self._client = client
 
     async def async_all(self) -> list[ListenerModel]:
         """Get all listeners.
 
-        Returns:
+        Returns
+        -------
             A validated API response payload.
+
         """
         response: ListenerAllResponse = await self._client.async_request_and_validate(
             "get", "/sensor/listeners", ListenerAllResponse
@@ -40,8 +44,10 @@ class Listener:
     async def async_definitions(self) -> list[ListenerDefinition]:
         """Get all listener definitions.
 
-        Returns:
+        Returns
+        -------
             A validated API response payload.
+
         """
         response: ListenerDefinitionResponse = (
             await self._client.async_request_and_validate(

--- a/aionotion/listener/models.py
+++ b/aionotion/listener/models.py
@@ -42,7 +42,7 @@ class PrimaryListenerInsight(DataClassDictMixin):
 
 @dataclass(frozen=True, kw_only=True)
 class ListenerInsights(DataClassDictMixin):
-    """Define listener insights:"""
+    """Define listener insights."""
 
     primary: PrimaryListenerInsight
 

--- a/aionotion/sensor/__init__.py
+++ b/aionotion/sensor/__init__.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from aionotion.sensor.models import Sensor as SensorModel
-from aionotion.sensor.models import SensorAllResponse, SensorGetResponse
+from aionotion.sensor.models import (
+    Sensor as SensorModel,
+    SensorAllResponse,
+    SensorGetResponse,
+)
 
 if TYPE_CHECKING:
     from aionotion.client import Client
@@ -18,15 +21,19 @@ class Sensor:
         """Initialize.
 
         Args:
+        ----
             client: The aionotion client
+
         """
         self._client = client
 
     async def async_all(self) -> list[SensorModel]:
         """Get all sensors.
 
-        Returns:
+        Returns
+        -------
             A validated API response payload.
+
         """
         response: SensorAllResponse = await self._client.async_request_and_validate(
             "get", "/sensors", SensorAllResponse
@@ -37,10 +44,13 @@ class Sensor:
         """Get a sensor by ID.
 
         Args:
+        ----
             sensor_id: The ID of the sensor to get.
 
         Returns:
+        -------
             A validated API response payload.
+
         """
         response: SensorGetResponse = await self._client.async_request_and_validate(
             "get", f"/sensors/{sensor_id}", SensorGetResponse

--- a/aionotion/system/__init__.py
+++ b/aionotion/system/__init__.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from aionotion.system.models import System as SystemModel
-from aionotion.system.models import SystemAllResponse, SystemGetResponse
+from aionotion.system.models import (
+    System as SystemModel,
+    SystemAllResponse,
+    SystemGetResponse,
+)
 
 if TYPE_CHECKING:
     from aionotion.client import Client
@@ -18,15 +21,19 @@ class System:
         """Initialize.
 
         Args:
+        ----
             client: The aionotion client
+
         """
         self._client = client
 
     async def async_all(self) -> list[SystemModel]:
         """Get all systems.
 
-        Returns:
+        Returns
+        -------
             An API response payload.
+
         """
         response: SystemAllResponse = await self._client.async_request_and_validate(
             "get", "/systems", SystemAllResponse
@@ -37,10 +44,13 @@ class System:
         """Get a system by ID.
 
         Args:
+        ----
             system_id: The ID of the system to get.
 
         Returns:
+        -------
             An API response payload.
+
         """
         response: SystemGetResponse = await self._client.async_request_and_validate(
             "get", f"/systems/{system_id}", SystemGetResponse

--- a/aionotion/user/__init__.py
+++ b/aionotion/user/__init__.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from aionotion.user.models import User as UserModel
 from aionotion.user.models import (
+    User as UserModel,
     UserInformationResponse,
     UserPreferences,
     UserPreferencesResponse,
@@ -15,22 +15,26 @@ if TYPE_CHECKING:
     from aionotion.client import Client
 
 
-class User:  # pylint: disable=too-few-public-methods
+class User:
     """Define an object to interact with user endpoints."""
 
     def __init__(self, client: Client) -> None:
         """Initialize.
 
         Args:
+        ----
             client: The aionotion client
+
         """
         self._client = client
 
     async def async_info(self) -> UserModel:
         """Get the user's information.
 
-        Returns:
+        Returns
+        -------
             A validated API response payload.
+
         """
         response: UserInformationResponse = (
             await self._client.async_request_and_validate(
@@ -44,8 +48,10 @@ class User:  # pylint: disable=too-few-public-methods
     async def async_preferences(self) -> UserPreferences:
         """Get user preferences.
 
-        Returns:
+        Returns
+        -------
             A validated API response payload.
+
         """
         response: UserPreferencesResponse = (
             await self._client.async_request_and_validate(

--- a/aionotion/util/auth.py
+++ b/aionotion/util/auth.py
@@ -1,5 +1,7 @@
 """Define auth utilities."""
 
+from __future__ import annotations
+
 from typing import Any
 
 import jwt
@@ -9,10 +11,13 @@ def decode_jwt(encoded_jwt: str) -> dict[str, Any]:
     """Decode and return a JWT.
 
     Args:
+    ----
         encoded_jwt: An encoded JWT.
 
     Returns:
+    -------
         A decoded JWT.
+
     """
     return jwt.decode(
         encoded_jwt,

--- a/aionotion/util/dt.py
+++ b/aionotion/util/dt.py
@@ -14,8 +14,10 @@ except ImportError:
 def utcnow() -> datetime:
     """Return the current UTC time.
 
-    Returns:
+    Returns
+    -------
         A ``datetime.datetime`` object.
+
     """
     return datetime.now(tz=UTC)
 
@@ -24,9 +26,12 @@ def utc_from_timestamp(timestamp: float) -> datetime:
     """Return a UTC time from a timestamp.
 
     Args:
+    ----
         timestamp: The epoch to convert.
 
     Returns:
+    -------
         A parsed ``datetime.datetime`` object.
+
     """
     return datetime.fromtimestamp(timestamp, tz=UTC)

--- a/examples/test_api.py
+++ b/examples/test_api.py
@@ -59,8 +59,8 @@ async def main() -> None:
             user_preferences = await client.user.async_preferences()
             _LOGGER.info("USER_PREFERENCES: %s", user_preferences)
             _LOGGER.info("============================================================")
-        except NotionError as err:
-            _LOGGER.error("There was an error: %s", err)
+        except NotionError:
+            _LOGGER.exception("There was an error")
 
 
 asyncio.run(main())

--- a/poetry.lock
+++ b/poetry.lock
@@ -1469,20 +1469,6 @@ docs = ["furo (>=2023.5.20)", "proselint (>=0.13)", "sphinx (>=7.0.1)", "sphinx-
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
 
 [[package]]
-name = "vulture"
-version = "2.11"
-description = "Find dead code"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "vulture-2.11-py2.py3-none-any.whl", hash = "sha256:12d745f7710ffbf6aeb8279ba9068a24d4e52e8ed333b8b044035c9d6b823aba"},
-    {file = "vulture-2.11.tar.gz", hash = "sha256:f0fbb60bce6511aad87ee0736c502456737490a82d919a44e6d92262cb35f1c2"},
-]
-
-[package.dependencies]
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-
-[[package]]
 name = "yamllint"
 version = "1.35.1"
 description = "A linter for YAML files."
@@ -1606,4 +1592,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "cf4e57e7783e5ed634fbcccdac77d0143e64e1a0d10beec099f95f010689fee4"
+content-hash = "1756477b821067cd4ac9303b61f72c5830e2060d6b9d7bc34f0faa4ec7beb058"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,6 @@ pyyaml = "^6.0.1"
 requests = ">=2.31.0"
 ruff = ">=0.0.261"
 types-pyjwt = "^1.7.1"
-vulture = "^2.6"
 yamllint = "^1.28.0"
 
 [tool.poetry.urls]
@@ -99,6 +98,7 @@ yamllint = "^1.28.0"
 Changelog = "https://github.com/bachya/aionotion/releases"
 
 [tool.pylint.BASIC]
+class-const-naming-style = "any"
 expected-line-ending-format = "LF"
 
 [tool.pylint.DESIGN]
@@ -107,46 +107,306 @@ max-attributes = 20
 [tool.pylint.FORMAT]
 max-line-length = 88
 
-[tool.pylint.MASTER]
+[tool.pylint.MAIN]
+py-version = "3.12"
 ignore = [
-  "tests",
+    "tests",
 ]
+# Use a conservative default here; 2 should speed up most setups and not hurt
+# any too bad. Override on command line as appropriate.
+jobs = 2
+init-hook = """\
+    from pathlib import Path; \
+    import sys; \
+
+    from pylint.config import find_default_config_files; \
+
+    sys.path.append( \
+        str(Path(next(find_default_config_files())).parent.joinpath('pylint/plugins'))
+    ) \
+    """
 load-plugins = [
-  "pylint.extensions.bad_builtin",
-  "pylint.extensions.code_style",
-  "pylint.extensions.docparams",
-  "pylint.extensions.docstyle",
-  "pylint.extensions.empty_comment",
-  "pylint.extensions.overlapping_exceptions",
-  "pylint.extensions.typing",
+    "pylint.extensions.code_style",
+    "pylint.extensions.typing",
+]
+persistent = false
+fail-on = [
+    "I",
 ]
 
 [tool.pylint."MESSAGES CONTROL"]
-# Reasons disabled:
-# invalid-enum-extension – We need to backport StrEnums until we drop Python 3.10
-# unnecessary-pass - This can hurt readability
 disable = [
-  "invalid-enum-extension",
-  "unnecessary-pass"
+    # These are subjective and should be left up to the developer:
+    "too-many-arguments",
+    "too-many-lines",
+    "too-many-locals",
+    "duplicate-code",
+
+    # Handled by ruff:
+    # Ref: <https://github.com/astral-sh/ruff/issues/970>
+    "anomalous-backslash-in-string",        # W605
+    "assert-on-string-literal",             # PLW0129
+    "assert-on-tuple",                      # F631
+    "await-outside-async",                  # PLE1142
+    "bad-classmethod-argument",             # N804
+    "bad-format-string",                    # W1302, F
+    "bad-format-string-key",                # W1300, F
+    "bad-str-strip-call",                   # PLE1310
+    "bad-string-format-type",               # PLE1307
+    "bare-except",                          # E722
+    "bidirectional-unicode",                # PLE2502
+    "binary-op-exception",                  # PLW0711
+    "broad-exception-caught",               # W0718
+    "cell-var-from-loop",                   # B023
+    "comparison-of-constants",              # PLR0133
+    "comparison-with-itself",               # PLR0124
+    "consider-alternative-union-syntax",    # UP007
+    "consider-iterating-dictionary",        # SIM118
+    "consider-merging-isinstance",          # PLR1701
+    "consider-using-alias",                 # UP006
+    "consider-using-dict-comprehension",    # C402
+    "consider-using-generator",             # C417
+    "consider-using-get",                   # SIM401
+    "consider-using-set-comprehension",     # C401
+    "consider-using-sys-exit",              # PLR1722
+    "consider-using-ternary",               # SIM108
+    "continue-in-finally",                  # PLE0116
+    "duplicate-bases",                      # PLE0241
+    "duplicate-except",                     # B014
+    "duplicate-key",                        # F601
+    "duplicate-string-formatting-argument", # F
+    "duplicate-value",                      # F
+    "empty-docstring",                      # D419
+    "eval-used",                            # S307
+    "exec-used",                            # S102
+    "expression-not-assigned",              # B018
+    "f-string-without-interpolation",       # F541
+    "forgotten-debug-statement",            # T100
+    "format-needs-mapping",                 # F502
+    "format-string-without-interpolation",  # F
+    "function-redefined",                   # F811
+    "global-variable-not-assigned",         # PLW0602
+    "implicit-str-concat",                  # ISC001
+    "import-self",                          # PLW0406
+    "inconsistent-quotes",                  # Q000
+    "invalid-all-object",                   # PLE0604
+    "invalid-character-backspace",          # PLE2510
+    "invalid-character-esc",                # PLE2513
+    "invalid-character-nul",                # PLE2514
+    "invalid-character-sub",                # PLE2512
+    "invalid-character-zero-width-space",   # PLE2515
+    "invalid-envvar-default",               # PLW1508
+    "invalid-name",                         # N815
+    "keyword-arg-before-vararg",            # B026
+    "line-too-long",                        # E501
+    "literal-comparison",                   # F632
+    "logging-format-interpolation",         # G
+    "logging-fstring-interpolation",        # G
+    "logging-not-lazy",                     # G
+    "logging-too-few-args",                 # PLE1206
+    "logging-too-many-args",                # PLE1205
+    "misplaced-future",                     # F404
+    "missing-class-docstring",              # D101
+    "missing-final-newline",                # W292
+    "missing-format-string-key",            # F524
+    "missing-function-docstring",           # D103
+    "missing-module-docstring",             # D100
+    "mixed-format-string",                  # F506
+    "multiple-imports",                     #E401
+    "named-expr-without-context",           # PLW0131
+    "nested-min-max",                       # PLW3301
+    "no-method-argument",                   # N805
+    "no-self-argument",                     # N805
+    "nonexistent-operator",                 # B002
+    "nonlocal-without-binding",             # PLE0117
+    "not-in-loop",                          # F701, F702
+    "notimplemented-raised",                # F901
+    "pointless-statement",                  # B018
+    "property-with-parameters",             # PLR0206
+    "raise-missing-from",                   # B904
+    "return-in-init",                       # PLE0101
+    "return-outside-function",              # F706
+    "singleton-comparison",                 # E711, E712
+    "subprocess-run-check",                 # PLW1510
+    "super-with-arguments",                 # UP008
+    "superfluous-parens",                   # UP034
+    "syntax-error",                         # E999
+    "too-few-format-args",                  # F524
+    "too-many-branches",                    # PLR0912
+    "too-many-format-args",                 # F522
+    "too-many-return-statements",           # PLR0911
+    "too-many-star-expressions",            # F622
+    "too-many-statements",                  # PLR0915
+    "trailing-comma-tuple",                 # COM818
+    "truncated-format-string",              # F501
+    "try-except-raise",                     # TRY302
+    "undefined-all-variable",               # F822
+    "undefined-variable",                   # F821
+    "ungrouped-imports",                    # I001
+    "unidiomatic-typecheck",                # E721
+    "unnecessary-comprehension",            # C416
+    "unnecessary-direct-lambda-call",       # PLC3002
+    "unnecessary-lambda-assignment",        # PLC3001
+    "unnecessary-pass",                     # PIE790
+    "unneeded-not",                         # SIM208
+    "unused-argument",                      # ARG001
+    "unused-format-string-argument",        # F507
+    "unused-format-string-key",             # F504
+    "unused-import",                        # F401
+    "unused-variable",                      # F841
+    "use-a-generator",                      # C417
+    "use-dict-literal",                     # C406
+    "use-list-literal",                     # C405
+    "used-prior-global-declaration",        # PLE0118
+    "useless-else-on-loop",                 # PLW0120
+    "useless-import-alias",                 # PLC0414
+    "useless-object-inheritance",           # UP004
+    "useless-return",                       # PLR1711
+    "wildcard-import",                      # F403
+    "wrong-import-order",                   # I001
+    "wrong-import-position",                # E402
+    "yield-inside-async-function",          # PLE1700
+    "yield-outside-function",               # F704
+
+    # Handled by mypy:
+    # Ref: <https://github.com/antonagestam/pylint-mypy-overlap>
+    "abstract-class-instantiated",
+    "arguments-differ",
+    "assigning-non-slot",
+    "assignment-from-no-return",
+    "assignment-from-none",
+    "bad-exception-cause",
+    "bad-format-character",
+    "bad-reversed-sequence",
+    "bad-super-call",
+    "bad-thread-instantiation",
+    "catching-non-exception",
+    "comparison-with-callable",
+    "deprecated-class",
+    "dict-iter-missing-items",
+    "format-combined-specification",
+    "global-variable-undefined",
+    "import-error",
+    "inconsistent-mro",
+    "inherit-non-class",
+    "init-is-generator",
+    "invalid-class-object",
+    "invalid-enum-extension",
+    "invalid-envvar-value",
+    "invalid-format-returned",
+    "invalid-hash-returned",
+    "invalid-metaclass",
+    "invalid-overridden-method",
+    "invalid-repr-returned",
+    "invalid-sequence-index",
+    "invalid-slice-index",
+    "invalid-slots",
+    "invalid-slots-object",
+    "invalid-star-assignment-target",
+    "invalid-str-returned",
+    "invalid-unary-operand-type",
+    "invalid-unicode-codec",
+    "isinstance-second-argument-not-valid-type",
+    "method-hidden",
+    "misplaced-format-function",
+    "missing-format-argument-key",
+    "missing-format-attribute",
+    "missing-kwoa",
+    "no-member",
+    "no-value-for-parameter",
+    "non-iterator-returned",
+    "non-str-assignment-to-dunder-name",
+    "nonlocal-and-global",
+    "not-a-mapping",
+    "not-an-iterable",
+    "not-async-context-manager",
+    "not-callable",
+    "not-context-manager",
+    "overridden-final-method",
+    "raising-bad-type",
+    "raising-non-exception",
+    "redundant-keyword-arg",
+    "relative-beyond-top-level",
+    "self-cls-assignment",
+    "signature-differs",
+    "star-needs-assignment-target",
+    "subclassed-final-class",
+    "super-without-brackets",
+    "too-many-function-args",
+    "typevar-double-variance",
+    "typevar-name-mismatch",
+    "unbalanced-dict-unpacking",
+    "unbalanced-tuple-unpacking",
+    "unexpected-keyword-arg",
+    "unhashable-member",
+    "unpacking-non-sequence",
+    "unsubscriptable-object",
+    "unsupported-assignment-operation",
+    "unsupported-binary-operation",
+    "unsupported-delete-operation",
+    "unsupported-membership-test",
+    "used-before-assignment",
+    "using-final-decorator-in-unsupported-version",
+    "wrong-exception-operation",
+]
+enable = [
+    "useless-suppression",
+    "use-symbolic-message-instead",
 ]
 
-[tool.pylint.REPORTS]
-score = false
+[tool.pylint.TYPING]
+runtime-typing = false
 
-[tool.pylint.SIMILARITIES]
-# Minimum lines number of a similarity.
-min-similarity-lines = 12
+[tool.pylint.CODE_STYLE]
+max-line-length-suggestions = 72
 
-# Ignore comments when computing similarities.
-ignore-comments = true
+[tool.ruff.lint]
+select = [
+    "ALL"
+]
 
-# Ignore docstrings when computing similarities.
-ignore-docstrings = true
+ignore = [
+    "ANN101",  # Missing type annotation for self
+    "D202",    # No blank lines allowed after function docstring
+    "D203",    # 1 blank line required before class docstring
+    "PLR0913", # This is subjective
+    "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
+    "PT012",   # `pytest.raises()` block should contain a single simple statement
+    "TCH",     # flake8-type-checking
 
-# Ignore imports when computing similarities.
-ignore-imports = true
+    # May conflict with the formatter:
+    # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "COM812",
+    "COM819",
+    "D206",
+    "D300",
+    "E111",
+    "E114",
+    "E117",
+    "ISC001",
+    "ISC002",
+    "Q000",
+    "Q001",
+    "Q002",
+    "Q003",
+    "W191",
+]
 
-[tool.vulture]
-min_confidence = 80
-paths = ["aionotion", "tests"]
-verbose = false
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+known-first-party = [
+    "aionotion",
+    "examples",
+    "tests",
+]
+combine-as-imports = true
+split-on-trailing-comma = false
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = [
+    "ARG001",   # Tests ofen have unused arguments
+    "FBT001",   # Test fixtures may be boolean values
+    "PLR2004",  # Checking for magic values in tests isn't helpful
+    "S101",     # Assertions are fine in tests
+    "SLF001",   # We'll access a lot of private third-party members in tests
+]

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,13 +1,13 @@
 """Define common test utilities."""
 
-import os
+from pathlib import Path
 from uuid import uuid4
 
 import jwt
 
 TEST_EMAIL = "user@email.com"
 TEST_PASSWORD = "password123"  # noqa: S105
-TEST_REFRESH_TOKEN = "abcde12345"
+TEST_REFRESH_TOKEN = "abcde12345"  # noqa: S105
 TEST_USER_UUID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
 
@@ -15,10 +15,13 @@ def generate_jwt(issued_at: float) -> bytes:
     """Generate a JWT.
 
     Args:
+    ----
         issued_at: A timestamp at which the JWT is issued.
 
     Returns:
+    -------
         The JWT string.
+
     """
     return jwt.encode(
         {
@@ -36,11 +39,14 @@ def load_fixture(filename: str) -> str:
     """Load a fixture.
 
     Args:
+    ----
         filename: The filename of the fixtures/ file to load.
 
     Returns:
+    -------
         A string containing the contents of the file.
+
     """
-    path = os.path.join(os.path.dirname(__file__), "fixtures", filename)
-    with open(path, encoding="utf-8") as fptr:
+    path = Path(f"{Path(__file__).parent}/fixtures/{filename}")
+    with Path.open(path, encoding="utf-8") as fptr:
         return fptr.read()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,14 @@
 """Define dynamic test fixtures."""
 
+from __future__ import annotations
+
 import json
-from collections.abc import Generator
 from time import time
 from typing import Any, cast
 
 import aiohttp
-import pytest
 from aresponses import ResponsesMockServer
+import pytest
 
 from tests.common import TEST_USER_UUID, generate_jwt, load_fixture
 
@@ -18,11 +19,14 @@ def _generate_auth_response_success(
     """Generate a successful auth response payload.
 
     Args:
+    ----
         access_token_issued_at: A timestamp at which an access token is issued.
         fixture_filename: The name of the fixture file.
 
     Returns:
+    -------
         A successful auth response payload.
+
     """
     if not access_token_issued_at:
         access_token_issued_at = time()
@@ -31,12 +35,26 @@ def _generate_auth_response_success(
     return response
 
 
+@pytest.fixture(name="access_token_issued_at")
+def _access_token_issued_at_fixture() -> None:
+    """Return a fixture for a timestamp at which an access token is issued.
+
+    We don't use time() as a default because we have some tests where we need this value
+    to be different *within* the function (and the fixture's default "function" scope
+    will generate a single value for the entire function). By setting this to None,
+    downstream fixtures can set a value that works for them.
+    """
+    return
+
+
 @pytest.fixture(name="auth_failure_response", scope="session")
 def auth_failure_response_fixture() -> dict[str, Any]:
     """Return a fixture for a failed auth response payload.
 
-    Returns:
+    Returns
+    -------
         A fixture for a failed auth response payload.
+
     """
     return cast(dict[str, Any], json.loads(load_fixture("auth_failure_response.json")))
 
@@ -48,10 +66,13 @@ def auth_credentials_success_response_fixture(
     """Return a fixture for a successful auth response payload.
 
     Args:
+    ----
         access_token_issued_at: A timestamp at which an access token is issued.
 
     Returns:
+    -------
         A fixture for a successful auth response payload.
+
     """
     return _generate_auth_response_success(
         access_token_issued_at, "auth_credentials_success_response.json"
@@ -60,10 +81,12 @@ def auth_credentials_success_response_fixture(
 
 @pytest.fixture(name="auth_legacy_credentials_success_response")
 def auth_legacy_credentials_success_response_fixture() -> dict[str, Any]:
-    """Return a fixture for a successful auth response payload (legacy)
+    """Return a fixture for a successful auth response payload (legacy).
 
-    Returns:
+    Returns
+    -------
         A fixture for a successful legacy auth response payload.
+
     """
     return cast(
         dict[str, Any],
@@ -78,41 +101,35 @@ def auth_refresh_token_success_response_fixture(
     """Return a fixture for a successful auth response payload.
 
     Args:
+    ----
         access_token_issued_at: A timestamp at which an access token is issued.
 
     Returns:
+    -------
         A fixture for a successful auth response payload.
+
     """
     return _generate_auth_response_success(
         access_token_issued_at, "auth_refresh_token_success_response.json"
     )
 
 
-@pytest.fixture(name="access_token_issued_at")
-def access_token_issued_at_fixture() -> None:
-    """Return a fixture for a timestamp at which an access token is issued.
-
-    We don't use time() as a default because we have some tests where we need this value
-    to be different *within* the function (and the fixture's default "function" scope
-    will generate a single value for the entire function). By setting this to None,
-    downstream fixtures can set a value that works for them.
-    """
-    return None
-
-
 @pytest.fixture(name="authenticated_notion_api_server")
 def authenticated_notion_api_server_fixture(
     auth_credentials_success_response: dict[str, Any],
     auth_refresh_token_success_response: dict[str, Any],
-) -> Generator[ResponsesMockServer, None, None]:
+) -> ResponsesMockServer:
     """Return a fixture that mocks an authenticated Notion API server.
 
     Args:
+    ----
         auth_credentials_success_response: An API response payload
         auth_refresh_token_success_response: An API response payload
 
     Yields:
+    ------
         A fixture that mocks an authenticated Notion API server.
+
     """
     server = ResponsesMockServer()
     server.add(
@@ -131,15 +148,17 @@ def authenticated_notion_api_server_fixture(
             auth_refresh_token_success_response, status=200
         ),
     )
-    yield server
+    return server
 
 
 @pytest.fixture(name="bad_api_response", scope="session")
 def bad_api_response_fixture() -> dict[str, Any]:
     """Return a fixture for a bad API response.
 
-    Returns:
+    Returns
+    -------
         A fixture for a bad API response.
+
     """
     return cast(dict[str, Any], json.loads(load_fixture("bad_api_response.json")))
 
@@ -148,8 +167,10 @@ def bad_api_response_fixture() -> dict[str, Any]:
 def bridge_all_response_fixture() -> dict[str, Any]:
     """Return a fixture for a successful GET /api/base_stations response.
 
-    Returns:
+    Returns
+    -------
         A fixture for a successful GET /api/base_stations response.
+
     """
     return cast(dict[str, Any], json.loads(load_fixture("bridge_all_response.json")))
 
@@ -158,8 +179,10 @@ def bridge_all_response_fixture() -> dict[str, Any]:
 def bridge_get_response_fixture() -> dict[str, Any]:
     """Return a fixture for a successful GET /api/base_stations/<ID> response.
 
-    Returns:
+    Returns
+    -------
         A fixture for a successful GET /api/base_stations/<ID> response.
+
     """
     return cast(dict[str, Any], json.loads(load_fixture("bridge_get_response.json")))
 
@@ -168,8 +191,10 @@ def bridge_get_response_fixture() -> dict[str, Any]:
 def listener_definitions_response_fixture() -> dict[str, Any]:
     """Return a fixture for a successful GET /api/listener_definitions response.
 
-    Returns:
+    Returns
+    -------
         A fixture for a successful GET /api/listener_definitions response.
+
     """
     return cast(
         dict[str, Any], json.loads(load_fixture("listener_definitions_response.json"))
@@ -180,8 +205,10 @@ def listener_definitions_response_fixture() -> dict[str, Any]:
 def sensor_all_response_fixture() -> dict[str, Any]:
     """Return a fixture for a successful GET /api/sensors response.
 
-    Returns:
+    Returns
+    -------
         A fixture for a successful GET /api/sensors response.
+
     """
     return cast(dict[str, Any], json.loads(load_fixture("sensor_all_response.json")))
 
@@ -190,8 +217,10 @@ def sensor_all_response_fixture() -> dict[str, Any]:
 def sensor_get_response_fixture() -> dict[str, Any]:
     """Return a fixture for a successful GET /api/sensors/<ID> response.
 
-    Returns:
+    Returns
+    -------
         A fixture for a successful GET /api/sensors/<ID> response.
+
     """
     return cast(dict[str, Any], json.loads(load_fixture("sensor_get_response.json")))
 
@@ -200,8 +229,10 @@ def sensor_get_response_fixture() -> dict[str, Any]:
 def sensor_listeners_response_fixture() -> dict[str, Any]:
     """Return a fixture for a successful GET /api/sensors/listeners response.
 
-    Returns:
+    Returns
+    -------
         A fixture for a successful GET /api/sensors/listeners response.
+
     """
     return cast(
         dict[str, Any], json.loads(load_fixture("sensor_listeners_response.json"))
@@ -212,8 +243,10 @@ def sensor_listeners_response_fixture() -> dict[str, Any]:
 def system_all_response_fixture() -> dict[str, Any]:
     """Return a fixture for a successful GET /api/systems response.
 
-    Returns:
+    Returns
+    -------
         A fixture for a successful GET /api/systems response.
+
     """
     return cast(dict[str, Any], json.loads(load_fixture("system_all_response.json")))
 
@@ -222,8 +255,10 @@ def system_all_response_fixture() -> dict[str, Any]:
 def system_get_response_fixture() -> dict[str, Any]:
     """Return a fixture for a successful GET /api/systems/<ID> response.
 
-    Returns:
+    Returns
+    -------
         A fixture for a successful GET /api/systems/<ID> response.
+
     """
     return cast(dict[str, Any], json.loads(load_fixture("system_get_response.json")))
 
@@ -232,8 +267,10 @@ def system_get_response_fixture() -> dict[str, Any]:
 def user_info_response_fixture() -> dict[str, Any]:
     """Return a fixture for a successful GET /api/users/<ID>/user_info response.
 
-    Returns:
+    Returns
+    -------
         A fixture for a successful GET /api/users/<ID>/user_info response.
+
     """
     return cast(dict[str, Any], json.loads(load_fixture("user_info_response.json")))
 
@@ -242,8 +279,10 @@ def user_info_response_fixture() -> dict[str, Any]:
 def user_preferences_response_fixture() -> dict[str, Any]:
     """Return a fixture for a successful GET /api/users/<ID>/user_preferences response.
 
-    Returns:
+    Returns
+    -------
         A fixture for a successful GET /api/users/<ID>/user_preferences response.
+
     """
     return cast(
         dict[str, Any], json.loads(load_fixture("user_preferences_response.json"))

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -6,14 +6,14 @@ from datetime import datetime, timezone
 from typing import Any
 
 import aiohttp
-import pytest
 from aresponses import ResponsesMockServer
+import pytest
 
 from aionotion import async_get_client_with_credentials
 from tests.common import TEST_EMAIL, TEST_PASSWORD
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_bridge_all(
     aresponses: ResponsesMockServer,
     authenticated_notion_api_server: ResponsesMockServer,
@@ -22,9 +22,11 @@ async def test_bridge_all(
     """Test getting all bridges.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_notion_api_server: A mock authenticated Notion API server
         bridge_all_response: An API response payload
+
     """
     async with authenticated_notion_api_server:
         authenticated_notion_api_server.add(
@@ -67,7 +69,7 @@ async def test_bridge_all(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_bridge_get(
     aresponses: ResponsesMockServer,
     authenticated_notion_api_server: ResponsesMockServer,
@@ -76,9 +78,11 @@ async def test_bridge_get(
     """Test getting a bridge by ID.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_notion_api_server: A mock authenticated Notion API server
         bridge_get_response: An API response payload
+
     """
     async with authenticated_notion_api_server:
         authenticated_notion_api_server.add(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,8 +10,8 @@ from typing import Any
 from unittest.mock import Mock
 
 import aiohttp
-import pytest
 from aresponses import ResponsesMockServer
+import pytest
 
 from aionotion import (
     async_get_client_with_credentials,
@@ -23,7 +23,7 @@ from aionotion.errors import InvalidCredentialsError, RequestError
 from .common import TEST_EMAIL, TEST_PASSWORD, TEST_REFRESH_TOKEN, TEST_USER_UUID
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_api_error(
     aresponses: ResponsesMockServer,
     authenticated_notion_api_server: ResponsesMockServer,
@@ -32,9 +32,11 @@ async def test_api_error(
     """Test an invalid API call.
 
     Args:
+    ----
         aresponses: An aresponses server
         authenticated_notion_api_server: A mock authenticated Notion API server
         bad_api_response: An API response payload
+
     """
     async with authenticated_notion_api_server:
         authenticated_notion_api_server.add(
@@ -54,7 +56,7 @@ async def test_api_error(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_auth_credentials_success(
     aresponses: ResponsesMockServer,
     authenticated_notion_api_server: ResponsesMockServer,
@@ -62,8 +64,10 @@ async def test_auth_credentials_success(
     """Test authenticating against the API with credentials.
 
     Args:
+    ----
         aresponses: An aresponses server
         authenticated_notion_api_server: A mock authenticated Notion API server
+
     """
     async with authenticated_notion_api_server, aiohttp.ClientSession() as session:
         client = await async_get_client_with_credentials(
@@ -74,15 +78,17 @@ async def test_auth_credentials_success(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_auth_failure(
     aresponses: ResponsesMockServer, auth_failure_response: dict[str, Any]
 ) -> None:
     """Test invalid credentials.
 
     Args:
+    ----
         aresponses: An aresponses server
         auth_failure_response: An API response payload
+
     """
     aresponses.add(
         "api.getnotion.com",
@@ -100,7 +106,7 @@ async def test_auth_failure(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_auth_legacy_credentials_success(
     aresponses: ResponsesMockServer,
     auth_legacy_credentials_success_response: dict[str, Any],
@@ -109,9 +115,11 @@ async def test_auth_legacy_credentials_success(
     """Test authenticating against the API with credentials (legacy).
 
     Args:
+    ----
         aresponses: An aresponses server
         auth_legacy_credentials_success_response: An API response payload
         bridge_all_response: An API response payload
+
     """
     aresponses.add(
         "api.getnotion.com",
@@ -140,7 +148,7 @@ async def test_auth_legacy_credentials_success(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_auth_refresh_token_success(
     aresponses: ResponsesMockServer,
     auth_refresh_token_success_response: dict[str, Any],
@@ -148,8 +156,10 @@ async def test_auth_refresh_token_success(
     """Test authenticating against the API with a refresh token.
 
     Args:
+    ----
         aresponses: An aresponses server
         auth_refresh_token_success_response: An API response payload
+
     """
     aresponses.add(
         "api.getnotion.com",
@@ -168,7 +178,7 @@ async def test_auth_refresh_token_success(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize("refresh_token", [None, "new_refresh_token"])
 async def test_auth_refresh_token_success_existing_client(
     aresponses: ResponsesMockServer,
@@ -178,9 +188,11 @@ async def test_auth_refresh_token_success_existing_client(
     """Test authenticating against the API with a refresh token with an existing client.
 
     Args:
+    ----
         aresponses: An aresponses server
         authenticated_notion_api_server: A mock authenticated Notion API server
         refresh_token: An optional refresh token
+
     """
     async with authenticated_notion_api_server, aiohttp.ClientSession() as session:
         client = await async_get_client_with_credentials(
@@ -198,7 +210,7 @@ async def test_auth_refresh_token_success_existing_client(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize("access_token_issued_at", [time() - 30 * 60])
 async def test_expired_access_token(
     aresponses: ResponsesMockServer,
@@ -209,10 +221,12 @@ async def test_expired_access_token(
     """Test handling an expired access token.
 
     Args:
+    ----
         aresponses: An aresponses server
         authenticated_notion_api_server: A mock authenticated Notion API server
         bridge_all_response: An API response payload
         caplog: A mocked logging utility.
+
     """
     caplog.set_level(logging.DEBUG)
 
@@ -237,7 +251,7 @@ async def test_expired_access_token(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize("access_token_issued_at", [time() - 30 * 60])
 async def test_expired_access_token_concurrent_calls(
     aresponses: ResponsesMockServer,
@@ -249,11 +263,13 @@ async def test_expired_access_token_concurrent_calls(
     """Test handling an expired access token with multiple concurrent calls.
 
     Args:
+    ----
         aresponses: An aresponses server
         authenticated_notion_api_server: A mock authenticated Notion API server.
         bridge_all_response: An API response payload.
         caplog: A mocked logging utility.
         sensor_all_response: An API response payload.
+
     """
     caplog.set_level(logging.DEBUG)
 
@@ -293,7 +309,7 @@ async def test_expired_access_token_concurrent_calls(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_premature_refresh_token(
     aresponses: ResponsesMockServer,
     authenticated_notion_api_server: ResponsesMockServer,
@@ -301,8 +317,10 @@ async def test_premature_refresh_token(
     """Test attempting to refresh the access token before actually getting one.
 
     Args:
+    ----
         aresponses: An aresponses server
         authenticated_notion_api_server: A mock authenticated Notion API server
+
     """
     async with authenticated_notion_api_server, aiohttp.ClientSession() as session:
         client = Client(session=session)
@@ -312,7 +330,7 @@ async def test_premature_refresh_token(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_no_explicit_session(
     aresponses: ResponsesMockServer,
     authenticated_notion_api_server: ResponsesMockServer,
@@ -320,8 +338,10 @@ async def test_no_explicit_session(
     """Test authentication without an explicit ClientSession.
 
     Args:
+    ----
         aresponses: An aresponses server
         authenticated_notion_api_server: A mock authenticated Notion API server
+
     """
     async with authenticated_notion_api_server:
         client = await async_get_client_with_credentials(TEST_EMAIL, TEST_PASSWORD)
@@ -330,7 +350,7 @@ async def test_no_explicit_session(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_refresh_token_callback(
     aresponses: ResponsesMockServer,
     auth_refresh_token_success_response: dict[str, Any],
@@ -339,9 +359,11 @@ async def test_refresh_token_callback(
     """Test that a refresh token callback is called when the access token is refreshed.
 
     Args:
+    ----
         aresponses: An aresponses server
         auth_refresh_token_success_response: An API response payload
         authenticated_notion_api_server: A mock authenticated Notion API server
+
     """
     async with authenticated_notion_api_server:
         authenticated_notion_api_server.add(
@@ -371,7 +393,7 @@ async def test_refresh_token_callback(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 @pytest.mark.parametrize("bridge_get_response", [{}])
 async def test_validation_error(
     authenticated_notion_api_server: ResponsesMockServer,
@@ -380,8 +402,10 @@ async def test_validation_error(
     """Test a response validation error.
 
     Args:
+    ----
         authenticated_notion_api_server: A mock authenticated Notion API server
         bridge_get_response: An API response payload
+
     """
     async with authenticated_notion_api_server:
         authenticated_notion_api_server.add(

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -2,21 +2,21 @@
 
 from __future__ import annotations
 
-import logging
 from datetime import datetime, timezone
+import logging
 from typing import Any
 from unittest.mock import Mock
 
 import aiohttp
-import pytest
 from aresponses import ResponsesMockServer
+import pytest
 
 from aionotion import async_get_client_with_credentials
 from aionotion.listener.models import ListenerKind
 from tests.common import TEST_EMAIL, TEST_PASSWORD
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_listener_all(
     aresponses: ResponsesMockServer,
     authenticated_notion_api_server: ResponsesMockServer,
@@ -26,10 +26,12 @@ async def test_listener_all(
     """Test getting listeners for all sensors.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_notion_api_server: A mock authenticated Notion API server
         caplog: A mocked logging utility.
         sensor_listeners_response: An API response payload
+
     """
     caplog.set_level(logging.INFO)
 
@@ -108,7 +110,7 @@ async def test_listener_all(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_listener_definitions(
     aresponses: ResponsesMockServer,
     authenticated_notion_api_server: ResponsesMockServer,
@@ -117,9 +119,11 @@ async def test_listener_definitions(
     """Test getting listeners for all sensors.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_notion_api_server: A mock authenticated Notion API server
         listener_definitions_response: An API response payload
+
     """
     async with authenticated_notion_api_server:
         authenticated_notion_api_server.add(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -6,14 +6,14 @@ from datetime import datetime, timezone
 from typing import Any
 
 import aiohttp
-import pytest
 from aresponses import ResponsesMockServer
+import pytest
 
 from aionotion import async_get_client_with_credentials
 from tests.common import TEST_EMAIL, TEST_PASSWORD
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_sensor_all(
     aresponses: ResponsesMockServer,
     authenticated_notion_api_server: ResponsesMockServer,
@@ -22,9 +22,11 @@ async def test_sensor_all(
     """Test getting all sensors.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_notion_api_server: A mock authenticated Notion API server
         sensor_all_response: An API response payload
+
     """
     async with authenticated_notion_api_server:
         authenticated_notion_api_server.add(
@@ -83,7 +85,7 @@ async def test_sensor_all(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_sensor_get(
     aresponses: ResponsesMockServer,
     authenticated_notion_api_server: ResponsesMockServer,
@@ -92,9 +94,11 @@ async def test_sensor_get(
     """Test getting a sensor by ID.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_notion_api_server: A mock authenticated Notion API server
         sensor_get_response: An API response payload
+
     """
     async with authenticated_notion_api_server:
         authenticated_notion_api_server.add(

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -5,15 +5,15 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 import aiohttp
-import pytest
 from aresponses import ResponsesMockServer
+import pytest
 
 from aionotion import async_get_client_with_credentials
 
 from .common import TEST_EMAIL, TEST_PASSWORD
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_system_all(
     aresponses: ResponsesMockServer,
     authenticated_notion_api_server: ResponsesMockServer,
@@ -22,9 +22,11 @@ async def test_system_all(
     """Test getting all systems.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_notion_api_server: A mock authenticated Notion API server
         system_all_response: A fixture for a system all response.
+
     """
     async with authenticated_notion_api_server:
         authenticated_notion_api_server.add(
@@ -74,7 +76,7 @@ async def test_system_all(
     aresponses.assert_plan_strictly_followed()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_system_get(
     aresponses: ResponsesMockServer,
     authenticated_notion_api_server: ResponsesMockServer,
@@ -83,9 +85,11 @@ async def test_system_get(
     """Test getting a system by ID.
 
     Args:
+    ----
         aresponses: An aresponses server.
         authenticated_notion_api_server: A mock authenticated Notion API server
         system_get_response: A fixture for a system get response.
+
     """
     async with authenticated_notion_api_server:
         authenticated_notion_api_server.add(

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -6,14 +6,14 @@ from datetime import datetime, timezone
 from typing import Any
 
 import aiohttp
-import pytest
 from aresponses import ResponsesMockServer
+import pytest
 
 from aionotion import async_get_client_with_credentials
 from tests.common import TEST_EMAIL, TEST_PASSWORD, TEST_USER_UUID
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_user_info(
     authenticated_notion_api_server: ResponsesMockServer,
     user_info_response: dict[str, Any],
@@ -21,8 +21,10 @@ async def test_user_info(
     """Test getting user preferences.
 
     Args:
+    ----
         authenticated_notion_api_server: A mock authenticated Notion API server
         user_info_response: A fixture for a user information response payload.
+
     """
     async with authenticated_notion_api_server:
         authenticated_notion_api_server.add(
@@ -53,7 +55,7 @@ async def test_user_info(
             )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio()
 async def test_user_preferences(
     authenticated_notion_api_server: ResponsesMockServer,
     user_preferences_response: dict[str, Any],
@@ -61,8 +63,10 @@ async def test_user_preferences(
     """Test getting user preferences.
 
     Args:
+    ----
         authenticated_notion_api_server: A mock authenticated Notion API server
         user_preferences_response: A fixture for a user preferences response payload.
+
     """
     async with authenticated_notion_api_server:
         authenticated_notion_api_server.add(

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -1,1 +1,0 @@
-cls  # unused variable (aionotion/sensor/models.py:179)


### PR DESCRIPTION
**Describe what the PR does:**

This PR uses more of `ruff`'s ruleset, which allows us to (a) be more conforming across the board, (b) eliminate redundant `pylint` and `mypy` checks, and (c) remove several redundant `pre-commit` hooks.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
